### PR TITLE
Fix builds on Rust 1.31

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
+  - 1.31.0
   - stable
   - beta
   - nightly

--- a/finalfusion-utils/src/bin/ff-convert.rs
+++ b/finalfusion-utils/src/bin/ff-convert.rs
@@ -118,7 +118,7 @@ fn main() {
         embeddings.set_metadata(metadata);
     }
 
-    write_embeddings(embeddings, &config.output_filename, config.output_format);
+    write_embeddings(&embeddings, &config.output_filename, config.output_format);
 }
 
 fn read_metadata(filename: impl AsRef<str>) -> Value {
@@ -140,7 +140,7 @@ fn read_embeddings(
     let f = File::open(filename).or_exit("Cannot open embeddings file", 1);
     let mut reader = BufReader::new(f);
 
-    use EmbeddingFormat::*;
+    use self::EmbeddingFormat::*;
     match embedding_format {
         FinalFusion => ReadEmbeddings::read_embeddings(&mut reader),
         FinalFusionMmap => MmapEmbeddings::mmap_embeddings(&mut reader),
@@ -154,14 +154,14 @@ fn read_embeddings(
 }
 
 fn write_embeddings(
-    embeddings: Embeddings<VocabWrap, StorageWrap>,
+    embeddings: &Embeddings<VocabWrap, StorageWrap>,
     filename: &str,
     embedding_format: EmbeddingFormat,
 ) {
     let f = File::create(filename).or_exit("Cannot create embeddings file", 1);
     let mut writer = BufWriter::new(f);
 
-    use EmbeddingFormat::*;
+    use self::EmbeddingFormat::*;
     match embedding_format {
         FinalFusion => embeddings.write_embeddings(&mut writer),
         FinalFusionMmap => Err(err_msg("Writing to this format is not supported")),

--- a/finalfusion-utils/src/lib.rs
+++ b/finalfusion-utils/src/lib.rs
@@ -16,7 +16,7 @@ pub enum EmbeddingFormat {
 
 impl EmbeddingFormat {
     pub fn try_from(format: impl AsRef<str>) -> Result<Self, Error> {
-        use EmbeddingFormat::*;
+        use self::EmbeddingFormat::*;
 
         match format.as_ref() {
             "finalfusion" => Ok(FinalFusion),
@@ -36,7 +36,7 @@ pub fn read_embeddings_view(
     let f = File::open(filename).context("Cannot open embeddings file")?;
     let mut reader = BufReader::new(f);
 
-    use EmbeddingFormat::*;
+    use self::EmbeddingFormat::*;
     let embeddings = match embedding_format {
         FinalFusion => ReadEmbeddings::read_embeddings(&mut reader),
         FinalFusionMmap => MmapEmbeddings::mmap_embeddings(&mut reader),

--- a/finalfusion/src/io.rs
+++ b/finalfusion/src/io.rs
@@ -110,7 +110,7 @@ pub(crate) mod private {
 
     impl ChunkIdentifier {
         pub fn try_from(identifier: u32) -> Option<Self> {
-            use ChunkIdentifier::*;
+            use self::ChunkIdentifier::*;
 
             match identifier {
                 1 => Some(SimpleVocab),


### PR DESCRIPTION
Rust 1.31 is the first version that supports Rust 2018. From now on, we
will use this as the lower bound.