### PR TITLE
Add NdNorms chunk

### DIFF
--- a/finalfusion-utils/src/lib.rs
+++ b/finalfusion-utils/src/lib.rs
@@ -40,9 +40,9 @@ pub fn read_embeddings_view(
     let embeddings = match embedding_format {
         FinalFusion => ReadEmbeddings::read_embeddings(&mut reader),
         FinalFusionMmap => MmapEmbeddings::mmap_embeddings(&mut reader),
-        Word2Vec => ReadWord2Vec::read_word2vec_binary(&mut reader, true).map(Embeddings::into),
-        Text => ReadText::read_text(&mut reader, true).map(Embeddings::into),
-        TextDims => ReadTextDims::read_text_dims(&mut reader, true).map(Embeddings::into),
+        Word2Vec => ReadWord2Vec::read_word2vec_binary(&mut reader).map(Embeddings::into),
+        Text => ReadText::read_text(&mut reader).map(Embeddings::into),
+        TextDims => ReadTextDims::read_text_dims(&mut reader).map(Embeddings::into),
     }
     .context("Cannot read embeddings")?;
 

--- a/finalfusion/src/io.rs
+++ b/finalfusion/src/io.rs
@@ -106,6 +106,7 @@ pub(crate) mod private {
         SubwordVocab = 3,
         QuantizedArray = 4,
         Metadata = 5,
+        NdNorms = 6,
     }
 
     impl ChunkIdentifier {
@@ -118,6 +119,7 @@ pub(crate) mod private {
                 3 => Some(SubwordVocab),
                 4 => Some(QuantizedArray),
                 5 => Some(Metadata),
+                6 => Some(NdNorms),
                 _ => None,
             }
         }

--- a/finalfusion/src/lib.rs
+++ b/finalfusion/src/lib.rs
@@ -11,6 +11,8 @@ pub mod io;
 
 pub mod metadata;
 
+pub mod norms;
+
 pub mod prelude;
 
 pub mod similarity;

--- a/finalfusion/src/norms.rs
+++ b/finalfusion/src/norms.rs
@@ -1,0 +1,145 @@
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::mem::size_of;
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use failure::{ensure, format_err, Error};
+use ndarray::Array1;
+
+use crate::io::private::{ChunkIdentifier, ReadChunk, TypeId, WriteChunk};
+use crate::util::padding;
+
+/// Trait for norm chunks.
+pub trait Norms {
+    /// Return the norm for the word at the given index.
+    fn norm(&self, idx: usize) -> f32;
+}
+
+/// Chunk for storing embedding l2 norms.
+///
+/// Word embeddings are always l2-normalized in finalfusion. Sometimes
+/// it is useful to get the original unnormalized embeddings. The
+/// norms chunk is used for storing norms of in-vocabulary embeddings.
+/// The unnormalized embedding can be reconstructed by multiplying the
+/// normalized embedding by its orginal l2 norm.
+#[derive(Clone, Debug)]
+pub struct NdNorms(pub Array1<f32>);
+
+impl Norms for NdNorms {
+    fn norm(&self, idx: usize) -> f32 {
+        self.0[idx]
+    }
+}
+
+impl ReadChunk for NdNorms {
+    fn read_chunk<R>(read: &mut R) -> Result<Self, Error>
+    where
+        R: Read + Seek,
+    {
+        let chunk_id = read.read_u32::<LittleEndian>()?;
+        let chunk_id = ChunkIdentifier::try_from(chunk_id)
+            .ok_or_else(|| format_err!("Unknown chunk identifier: {}", chunk_id))?;
+        ensure!(
+            chunk_id == ChunkIdentifier::NdNorms,
+            "Cannot read chunk {:?} as NdNorms",
+            chunk_id
+        );
+
+        // Read and discard chunk length.
+        read.read_u64::<LittleEndian>()?;
+
+        let len = read.read_u64::<LittleEndian>()? as usize;
+
+        ensure!(
+            read.read_u32::<LittleEndian>()? == f32::type_id(),
+            "Expected single precision floating point matrix for NdNorms."
+        );
+
+        let n_padding = padding::<f32>(read.seek(SeekFrom::Current(0))?);
+        read.seek(SeekFrom::Current(n_padding as i64))?;
+
+        let mut data = vec![0f32; len];
+        read.read_f32_into::<LittleEndian>(&mut data)?;
+
+        Ok(NdNorms(Array1::from_vec(data)))
+    }
+}
+
+impl WriteChunk for NdNorms {
+    fn chunk_identifier(&self) -> ChunkIdentifier {
+        ChunkIdentifier::NdNorms
+    }
+
+    fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
+    where
+        W: Write + Seek,
+    {
+        write.write_u32::<LittleEndian>(ChunkIdentifier::NdNorms as u32)?;
+        let n_padding = padding::<f32>(write.seek(SeekFrom::Current(0))?);
+        // Chunk size: len (u64), type id (u32), padding ([0,4) bytes), vector.
+        let chunk_len = size_of::<u64>()
+            + size_of::<u32>()
+            + n_padding as usize
+            + (self.0.len() * size_of::<f32>());
+        write.write_u64::<LittleEndian>(chunk_len as u64)?;
+        write.write_u64::<LittleEndian>(self.0.len() as u64)?;
+        write.write_u32::<LittleEndian>(f32::type_id())?;
+
+        let padding = vec![0; n_padding as usize];
+        write.write_all(&padding)?;
+
+        for &val in self.0.iter() {
+            write.write_f32::<LittleEndian>(val)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Read, Seek, SeekFrom};
+
+    use byteorder::{LittleEndian, ReadBytesExt};
+    use ndarray::Array1;
+
+    use crate::io::private::{ReadChunk, WriteChunk};
+    use crate::norms::NdNorms;
+
+    const LEN: usize = 100;
+
+    fn test_ndnorms() -> NdNorms {
+        NdNorms(Array1::range(0., LEN as f32, 1.))
+    }
+
+    fn read_chunk_size(read: &mut impl Read) -> u64 {
+        // Skip identifier.
+        read.read_u32::<LittleEndian>().unwrap();
+
+        // Return chunk length.
+        read.read_u64::<LittleEndian>().unwrap()
+    }
+
+    #[test]
+    fn ndnorms_correct_chunk_size() {
+        let check_arr = test_ndnorms();
+        let mut cursor = Cursor::new(Vec::new());
+        check_arr.write_chunk(&mut cursor).unwrap();
+        cursor.seek(SeekFrom::Start(0)).unwrap();
+
+        let chunk_size = read_chunk_size(&mut cursor);
+        assert_eq!(
+            cursor.read_to_end(&mut Vec::new()).unwrap(),
+            chunk_size as usize
+        );
+    }
+
+    #[test]
+    fn ndnorms_write_read_roundtrip() {
+        let check_arr = test_ndnorms();
+        let mut cursor = Cursor::new(Vec::new());
+        check_arr.write_chunk(&mut cursor).unwrap();
+        cursor.seek(SeekFrom::Start(0)).unwrap();
+        let arr = NdNorms::read_chunk(&mut cursor).unwrap();
+        assert_eq!(arr.0, check_arr.0);
+    }
+}

--- a/finalfusion/src/prelude.rs
+++ b/finalfusion/src/prelude.rs
@@ -1,14 +1,13 @@
 //! Prelude exports the most commonly-used types and traits.
 
-pub use crate::embeddings::Embeddings;
+pub use crate::embeddings::{Embeddings, Quantize};
 
 pub use crate::io::{MmapEmbeddings, ReadEmbeddings, ReadMetadata, WriteEmbeddings};
 
 pub use crate::metadata::Metadata;
 
 pub use crate::storage::{
-    MmapArray, NdArray, Quantize, QuantizedArray, Storage, StorageView, StorageViewWrap,
-    StorageWrap,
+    MmapArray, NdArray, QuantizedArray, Storage, StorageView, StorageViewWrap, StorageWrap,
 };
 
 pub use crate::text::{ReadText, ReadTextDims, WriteText, WriteTextDims};

--- a/finalfusion/src/similarity.rs
+++ b/finalfusion/src/similarity.rs
@@ -362,7 +362,7 @@ mod tests {
     fn test_similarity() {
         let f = File::open("testdata/similarity.bin").unwrap();
         let mut reader = BufReader::new(f);
-        let embeddings = Embeddings::read_word2vec_binary(&mut reader, true).unwrap();
+        let embeddings = Embeddings::read_word2vec_binary(&mut reader).unwrap();
 
         let result = embeddings.similarity("Berlin", 40);
         assert!(result.is_some());
@@ -389,7 +389,7 @@ mod tests {
     fn test_similarity_limit() {
         let f = File::open("testdata/similarity.bin").unwrap();
         let mut reader = BufReader::new(f);
-        let embeddings = Embeddings::read_word2vec_binary(&mut reader, true).unwrap();
+        let embeddings = Embeddings::read_word2vec_binary(&mut reader).unwrap();
 
         let result = embeddings.similarity("Stuttgart", 10);
         assert!(result.is_some());
@@ -407,7 +407,7 @@ mod tests {
     fn test_analogy() {
         let f = File::open("testdata/analogy.bin").unwrap();
         let mut reader = BufReader::new(f);
-        let embeddings = Embeddings::read_word2vec_binary(&mut reader, true).unwrap();
+        let embeddings = Embeddings::read_word2vec_binary(&mut reader).unwrap();
 
         let result = embeddings.analogy("Paris", "Frankreich", "Berlin", 40);
         assert!(result.is_some());

--- a/finalfusion/src/tests.rs
+++ b/finalfusion/src/tests.rs
@@ -3,13 +3,13 @@ use std::io::{BufReader, Read, Seek, SeekFrom};
 
 use crate::embeddings::Embeddings;
 use crate::vocab::Vocab;
-use crate::word2vec::{ReadWord2Vec, WriteWord2Vec};
+use crate::word2vec::{ReadWord2VecRaw, WriteWord2Vec};
 
 #[test]
 fn test_read_word2vec_binary() {
     let f = File::open("testdata/similarity.bin").unwrap();
     let mut reader = BufReader::new(f);
-    let embeddings = Embeddings::read_word2vec_binary(&mut reader, false).unwrap();
+    let embeddings = Embeddings::read_word2vec_binary_raw(&mut reader).unwrap();
     assert_eq!(41, embeddings.vocab().len());
     assert_eq!(100, embeddings.dims());
 }
@@ -22,7 +22,7 @@ fn test_word2vec_binary_roundtrip() {
 
     // Read embeddings.
     reader.seek(SeekFrom::Start(0)).unwrap();
-    let embeddings = Embeddings::read_word2vec_binary(&mut reader, false).unwrap();
+    let embeddings = Embeddings::read_word2vec_binary_raw(&mut reader).unwrap();
 
     // Write embeddings to a byte vector.
     let mut output = Vec::new();

--- a/finalfusion/src/util.rs
+++ b/finalfusion/src/util.rs
@@ -1,4 +1,11 @@
-use ndarray::ArrayViewMut1;
+use std::mem::size_of;
+
+use ndarray::{Array1, ArrayViewMut1, ArrayViewMut2};
+
+pub fn padding<T>(pos: u64) -> u64 {
+    let size = size_of::<T>() as u64;
+    size - (pos % size)
+}
 
 pub fn l2_normalize(mut v: ArrayViewMut1<f32>) -> f32 {
     let norm = v.dot(&v).sqrt();
@@ -8,4 +15,13 @@ pub fn l2_normalize(mut v: ArrayViewMut1<f32>) -> f32 {
     }
 
     norm
+}
+
+pub fn l2_normalize_array(mut v: ArrayViewMut2<f32>) -> Array1<f32> {
+    let mut norms = Vec::with_capacity(v.rows());
+    for embedding in v.outer_iter_mut() {
+        norms.push(l2_normalize(embedding));
+    }
+
+    norms.into()
 }


### PR DESCRIPTION
This chunk stores the norms of in-vocabulary words. If an Embedding
data structure stores NdNorms, the vector norms can be queried with
the `embedding_with_norm` method.

When converting from word2vec/text in `ff-convert`, always normalize
embeddings and store norms.

Some random points:

* I still need to add some more unit tests.
* The norms chunk is currently not a generic type of `Embedding`. This is to keep the type signature simple while we still can. This may change later. It will definitely be necessary when we want to make it memory mappable.
* The norms chunk is optional, for compatibility with existing finalfusion embeddings. Since we can assume the (known) *word* embeddings to be normalized, the norm 1 is returned when the chunk is absent.
* `ff-convert` from word2vec and text now always normalizes the embeddings and creates a norms chunk.
* I am considering to multiply the unit vectors by their norms when converting *to* word2vec or text embeddings, to restore the raw, unnormalized embeddings. However, this is currently not done.
* I tried to make the norms mandatory (normalizing the embeddings and computing norms when the chunk is not present). However, this poses problems, because mmaped and quantized embeddings cannot be updated.
* The traits for reading word2vec/text embeddings still have an argument for normalization. These are still needed for roundtrip unit tests. I might make a crate-private trait for unnormalized reading and call this from the public trait that always normalizes. This would allow us to keep the roundtrip unit tests, while always normalizing in the public interface. (Done now for `ReadWord2Vec`)