### PR TITLE
Write{Word2VecBinary,Text}: Support writing of unnormalized embeddings

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -436,6 +436,15 @@ pub struct EmbeddingWithNorm<'a> {
     pub norm: f32,
 }
 
+impl<'a> EmbeddingWithNorm<'a> {
+    // Compute the unnormalized embedding.
+    pub fn into_unnormalized(self) -> Array1<f32> {
+        let mut unnormalized = self.embedding.into_owned();
+        unnormalized *= self.norm;
+        unnormalized
+    }
+}
+
 /// Iterator over embeddings.
 pub struct Iter<'a> {
     storage: &'a Storage,


### PR DESCRIPTION
Preparation for supporting writing of unnormalized embeddings in `finalfusion-utils`. Since this is an API change, we need to bump the version rather than doing a point release.