### PR TITLE
Implement a library-specific error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ exclude = [
 
 [dependencies]
 byteorder = "1"
-failure = "0.1"
 fnv = "1"
 itertools = "0.8"
 memmap = "0.7"

--- a/src/text.rs
+++ b/src/text.rs
@@ -159,7 +159,8 @@ where
     };
 
     for line in reader.lines() {
-        let line = line?;
+        let line =
+            line.map_err(|e| ErrorKind::io_error("Cannot read line from embedding file", e))?;
         let mut parts = line.split_whitespace();
 
         let word = parts
@@ -242,7 +243,8 @@ where
             };
 
             let embed_str = embed.as_view().iter().map(ToString::to_string).join(" ");
-            writeln!(write, "{} {}", word, embed_str)?;
+            writeln!(write, "{} {}", word, embed_str)
+                .map_err(|e| ErrorKind::io_error("Cannot write word embedding", e))?;
         }
 
         Ok(())
@@ -274,7 +276,8 @@ where
     S: Storage,
 {
     fn write_text_dims(&self, write: &mut W, unnormalize: bool) -> Result<()> {
-        writeln!(write, "{} {}", self.vocab().len(), self.dims())?;
+        writeln!(write, "{} {}", self.vocab().len(), self.dims())
+            .map_err(|e| ErrorKind::io_error("Cannot write word embedding matrix shape", e))?;
         self.write_text(write, unnormalize)
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -43,7 +43,9 @@ pub fn read_number(reader: &mut BufRead, delim: u8) -> Result<usize> {
 
 pub fn read_string(reader: &mut BufRead, delim: u8) -> Result<String> {
     let mut buf = Vec::new();
-    reader.read_until(delim, &mut buf)?;
+    reader
+        .read_until(delim, &mut buf)
+        .map_err(|e| ErrorKind::io_error("Cannot read string", e))?;
     buf.pop();
     Ok(String::from_utf8(buf)
         .map_err(|e| ErrorKind::Format(format!("Token contains invalid UTF-8: {}", e)))?)


### PR DESCRIPTION
Design choices:

- `Error` is in the `io` module. We might want to introduce other types of errors when necessary, but we probably want to separate I/O errors from other errors.
- I had a very fine-grained `ErrorKind` enum, but this seems to make downstream error handling a bit dreadful. So, I decided to make one enum variant `Format` for file format errors (something different in the format than expected). It's an enum to keep the possibility for more fine-grained errors open.

The `Error` with one variant for crate-specific errors, which wraps `ErrorKind` was inspired by a lot of other crates that follow this approach, where an Error enum wraps the different downstream error types and has one variant for crate-specific errors.

~What I hope to do in a future PR: more fine-grained errors than just an I/O error when reading/writing data, so that we can return errors like `Failed to read embedding matrix, reason: some io::Error explanation`. But I first wanted to have the basic structure set up for errors.~ Added to this PR!