### PR TITLE
Add a criterion benchmark for the NGrams iterator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,5 @@ addons:
     packages:
       - libopenblas-dev
       - gfortran
+after_success:
+  - ci/after-success.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,9 @@ toml = "0.5"
 [dev-dependencies]
 maplit = "1"
 lazy_static = "1"
+criterion = "0.2"
+
+[[bench]]
+name = "subword"
+harness = false
+

--- a/benches/subword.rs
+++ b/benches/subword.rs
@@ -1,0 +1,33 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
+
+use finalfusion::subword::SubwordIndices;
+
+const MIN_N: usize = 3;
+const MAX_N: usize = 6;
+const WORD_LENGTH: usize = 10;
+
+fn subwords(string: &str, min_n: usize, max_n: usize) -> u64 {
+    // Sum the subword indices, to ensure that the benchmark
+    // evaluates them.
+    string
+        .subword_indices(min_n, max_n, 21)
+        .into_iter()
+        .fold(0, |sum, v| sum.wrapping_add(v))
+}
+
+fn ngrams_benchmark(c: &mut Criterion) {
+    let mut rng = thread_rng();
+    let string = rng
+        .sample_iter(&Alphanumeric)
+        .take(WORD_LENGTH)
+        .collect::<String>();
+
+    c.bench_function("subwords-len-10-minn-3-maxn-6", move |b| {
+        b.iter(|| subwords(&string, black_box(MIN_N), black_box(MAX_N)))
+    });
+}
+
+criterion_group!(benches, ngrams_benchmark);
+criterion_main!(benches);

--- a/ci/after-success.sh
+++ b/ci/after-success.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ] && [ "$TRAVIS_RUST_VERSION" == "stable" ]; then
+    REMOTE_URL="$(git config --get remote.origin.url)";
+    cd ${TRAVIS_BUILD_DIR}/.. && \
+    git clone ${REMOTE_URL} "${TRAVIS_REPO_SLUG}-bench" && \
+    cd  "${TRAVIS_REPO_SLUG}-bench" && \
+    # Bench master
+    git checkout master && \
+    cargo bench && \
+    # Bench pull request
+    git checkout ${TRAVIS_COMMIT} && \
+    cargo bench;
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod similarity;
 
 pub mod storage;
 
-pub(crate) mod subword;
+pub mod subword;
 
 pub mod text;
 


### PR DESCRIPTION
I had to make the `subword` module visible (for now), since benchmarks use the library as an external module. I think we can eventually resolve this, by benchmarking Nicole's proposed method.

`cargo bench` will show statistics in the terminal. If gnuplot is installed, nice graphs will also be generated.


![Gnuplot](https://user-images.githubusercontent.com/49398/61122726-d5322000-a4a2-11e9-9e8d-8d455d23e292.png)
