### PR TITLE
Specialize NGrams to string slices

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,65 @@
+use std::collections::VecDeque;
 use std::io::BufRead;
 use std::mem::size_of;
 
 use crate::io::{Error, ErrorKind, Result};
 use ndarray::{Array1, ArrayViewMut1, ArrayViewMut2};
+
+/// Conversion from an `Iterator` into a collection with a given
+/// capacity.
+pub trait FromIteratorWithCapacity<T> {
+    /// Construct a collection with the given capacity from an iterator.
+    fn from_iter_with_capacity<I>(iter: I, capacity: usize) -> Self
+    where
+        I: IntoIterator<Item = T>;
+}
+
+impl<T> FromIteratorWithCapacity<T> for Vec<T> {
+    fn from_iter_with_capacity<I>(iter: I, capacity: usize) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut v = Vec::with_capacity(capacity);
+        v.extend(iter.into_iter());
+        v
+    }
+}
+
+impl<T> FromIteratorWithCapacity<T> for VecDeque<T> {
+    fn from_iter_with_capacity<I>(iter: I, capacity: usize) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut v = VecDeque::with_capacity(capacity);
+        v.extend(iter.into_iter());
+        v
+    }
+}
+
+/// Collect iterms from an `Iterator` into a collection with a
+/// capacity.
+pub trait CollectWithCapacity {
+    type Item;
+
+    /// Transform an iterator into a collection with the given capacity.
+    fn collect_with_capacity<B>(self, capacity: usize) -> B
+    where
+        B: FromIteratorWithCapacity<Self::Item>;
+}
+
+impl<I, T> CollectWithCapacity for I
+where
+    I: Iterator<Item = T>,
+{
+    type Item = T;
+
+    fn collect_with_capacity<B>(self, capacity: usize) -> B
+    where
+        B: FromIteratorWithCapacity<Self::Item>,
+    {
+        B::from_iter_with_capacity(self, capacity)
+    }
+}
 
 pub fn padding<T>(pos: u64) -> u64 {
     let size = size_of::<T>() as u64;


### PR DESCRIPTION
NGram::new now takes a string slice, rather than a Vec of a generic
type. The resulting iterator returns the n-grams as string slices.

In SubwordIndices::subword_indices, we used to compute the hash of an
n-gram over Vec<char>. The implementation of Hash for Vec first adds
the length of the Vec to the hasher, followed by the individual
element. However, we want to avoid collecting the characters in a Vec
or iterating over the characters twice in order to get the length.
For this reason, NGrams now couples string slices with their length in
characters using the auxiliary StrWithCharLen type.

---

I have added benchmarks to CI in the previous PR, so we should be able to see the performance relative to the old implementation in the build log for Rust stable.