### PR TITLE
Separate index computation from subword iteration

### DIFF
--- a/benches/subword.rs
+++ b/benches/subword.rs
@@ -2,17 +2,17 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 
-use finalfusion::subword::SubwordIndices;
+use finalfusion::subword::{FinalfusionHashIndexer, Indexer, SubwordIndices};
 
 const MIN_N: usize = 3;
 const MAX_N: usize = 6;
 const WORD_LENGTH: usize = 10;
 
-fn subwords(string: &str, min_n: usize, max_n: usize) -> u64 {
+fn subwords(string: &str, min_n: usize, max_n: usize, indexer: &impl Indexer) -> u64 {
     // Sum the subword indices, to ensure that the benchmark
     // evaluates them.
     string
-        .subword_indices(min_n, max_n, 21)
+        .subword_indices(min_n, max_n, indexer)
         .into_iter()
         .fold(0, |sum, v| sum.wrapping_add(v))
 }
@@ -24,8 +24,10 @@ fn ngrams_benchmark(c: &mut Criterion) {
         .take(WORD_LENGTH)
         .collect::<String>();
 
+    let indexer = FinalfusionHashIndexer::new(21);
+
     c.bench_function("subwords-len-10-minn-3-maxn-6", move |b| {
-        b.iter(|| subwords(&string, black_box(MIN_N), black_box(MAX_N)))
+        b.iter(|| subwords(&string, black_box(MIN_N), black_box(MAX_N), &indexer))
     });
 }
 


### PR DESCRIPTION
The extraction of subwords + subword indices was tied to one specific
implementation of index generation (finalfusion-style FNV hashing +
bucket mapping). This change separates index generation to an
`Indexer` trait + `HashIndexer` implementation.

This change accomodates future support of other indexing functions
(such as fastText).