### PR TITLE
Add the BucketIndexer trait and implement for HashIndexer

### DIFF
--- a/benches/subword.rs
+++ b/benches/subword.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 
-use finalfusion::subword::{FinalfusionHashIndexer, Indexer, SubwordIndices};
+use finalfusion::subword::{BucketIndexer, FinalfusionHashIndexer, Indexer, SubwordIndices};
 
 const MIN_N: usize = 3;
 const MAX_N: usize = 6;

--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -8,7 +8,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::io::private::{ChunkIdentifier, ReadChunk, WriteChunk};
 use crate::io::{Error, ErrorKind, Result};
-use crate::subword::{FinalfusionHashIndexer, SubwordIndices};
+use crate::subword::{BucketIndexer, FinalfusionHashIndexer, SubwordIndices};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// Index of a vocabulary word.


### PR DESCRIPTION
This trait derives from Indexer and specifies the constructor for
bucketing-based indexers.

This is a minimalistic PR, but the small trait will be useful in the `SubwordVocab` changes, permitting every bucketing-based indexer to be constructed in the same manner.