### PR TITLE
Add read(_dims)?_lossy

### DIFF
--- a/testdata/utf8-incomplete.dims
+++ b/testdata/utf8-incomplete.dims
@@ -1,0 +1,4 @@
+3 3
+meren -1 0 1
+zee√n 1 0 -1
+rivieren 0 -1 1

--- a/testdata/utf8-incomplete.txt
+++ b/testdata/utf8-incomplete.txt
@@ -1,0 +1,3 @@
+meren -1 0 1
+zee√n 1 0 -1
+rivieren 0 -1 1


### PR DESCRIPTION
The lossy read variants allow invalid UTF-8 byte sequences in tokens.
Such sequences are replaced by the replacement character.

Will do the lossy variant of word2vec in a separate PR.