### PR TITLE
Mark trait objects with dyn

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -464,7 +464,7 @@ impl<'a> EmbeddingWithNorm<'a> {
 
 /// Iterator over embeddings.
 pub struct Iter<'a> {
-    storage: &'a Storage,
+    storage: &'a dyn Storage,
     inner: Enumerate<slice::Iter<'a, String>>,
 }
 
@@ -480,7 +480,7 @@ impl<'a> Iterator for Iter<'a> {
 
 /// Iterator over embeddings.
 pub struct IterWithNorms<'a> {
-    storage: &'a Storage,
+    storage: &'a dyn Storage,
     norms: Option<&'a NdNorms>,
     inner: Enumerate<slice::Iter<'a, String>>,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -85,7 +85,7 @@ pub fn l2_normalize_array(mut v: ArrayViewMut2<f32>) -> Array1<f32> {
     norms.into()
 }
 
-pub fn read_number(reader: &mut BufRead, delim: u8) -> Result<usize> {
+pub fn read_number(reader: &mut dyn BufRead, delim: u8) -> Result<usize> {
     let field_str = read_string(reader, delim, false)?;
     field_str
         .parse()
@@ -98,7 +98,7 @@ pub fn read_number(reader: &mut BufRead, delim: u8) -> Result<usize> {
         .map_err(Error::from)
 }
 
-pub fn read_string(reader: &mut BufRead, delim: u8, lossy: bool) -> Result<String> {
+pub fn read_string(reader: &mut dyn BufRead, delim: u8, lossy: bool) -> Result<String> {
     let mut buf = Vec::new();
     reader
         .read_until(delim, &mut buf)


### PR DESCRIPTION
Rust 1.37.0 gives warnings for bare trait objects.