### PR TITLE
Verify that the vocabulary indexing matches the embeddings shape.

### DIFF
--- a/src/compat/fasttext/indexer.rs
+++ b/src/compat/fasttext/indexer.rs
@@ -44,6 +44,10 @@ impl Indexer for FastTextIndexer {
     fn index_ngram(&self, ngram: &StrWithCharLen) -> u64 {
         u64::from(fasttext_hash(ngram.as_str()) % self.buckets)
     }
+
+    fn upper_bound(&self) -> u64 {
+        u64::from(self.buckets)
+    }
 }
 
 /// fastText FNV-1a implementation.

--- a/src/compat/fasttext/io.rs
+++ b/src/compat/fasttext/io.rs
@@ -97,11 +97,11 @@ impl ReadFastTextPrivate for Embeddings<FastTextSubwordVocab, NdArray> {
         add_subword_embeddings(&vocab, &mut storage);
         #[allow(clippy::deref_addrof)]
         let norms = NdNorms(l2_normalize_array(
-            storage.view_mut().slice_mut(s![0..vocab.len(), ..]),
+            storage.view_mut().slice_mut(s![0..vocab.words_len(), ..]),
         ));
 
         // Verify that vocab and storage shapes match.
-        if storage.shape().0 != vocab.len() + config.bucket as usize {
+        if storage.shape().0 != vocab.words_len() + config.bucket as usize {
             return Err(Error::Shape(ShapeError::from_kind(
                 ShapeErrorKind::IncompatibleShape,
             )));

--- a/src/compat/text.rs
+++ b/src/compat/text.rs
@@ -340,7 +340,7 @@ where
     S: Storage,
 {
     fn write_text_dims(&self, write: &mut W, unnormalize: bool) -> Result<()> {
-        writeln!(write, "{} {}", self.vocab().len(), self.dims())
+        writeln!(write, "{} {}", self.vocab().words_len(), self.dims())
             .map_err(|e| ErrorKind::io_error("Cannot write word embedding matrix shape", e))?;
         self.write_text(write, unnormalize)
     }

--- a/src/compat/word2vec.rs
+++ b/src/compat/word2vec.rs
@@ -152,7 +152,7 @@ where
     where
         W: Write,
     {
-        writeln!(w, "{} {}", self.vocab().len(), self.dims())
+        writeln!(w, "{} {}", self.vocab().words_len(), self.dims())
             .map_err(|e| ErrorKind::io_error("Cannot write word embedding matrix shape", e))?;
 
         for (word, embed_norm) in self.iter_with_norms() {
@@ -207,7 +207,7 @@ mod tests {
         let f = File::open("testdata/similarity.bin").unwrap();
         let mut reader = BufReader::new(f);
         let embeddings = Embeddings::read_word2vec_binary_raw(&mut reader, false).unwrap();
-        assert_eq!(41, embeddings.vocab().len());
+        assert_eq!(41, embeddings.vocab().words_len());
         assert_eq!(100, embeddings.dims());
     }
 

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -40,6 +40,7 @@ pub struct Embeddings<V, S> {
 impl<V, S> Embeddings<V, S>
 where
     V: Vocab,
+    S: Storage,
 {
     /// Construct an embeddings from a vocabulary, storage, and norms.
     ///
@@ -48,9 +49,14 @@ where
     /// computational cost.
     pub fn new(metadata: Option<Metadata>, vocab: V, storage: S, norms: NdNorms) -> Self {
         assert_eq!(
-            vocab.len(),
+            vocab.words_len(),
             norms.0.len(),
             "Vocab and norms do not have the same length"
+        );
+        assert_eq!(
+            vocab.vocab_len(),
+            storage.shape().0,
+            "Max vocab index must match number of rows in the embedding matrix."
         );
 
         Embeddings {
@@ -207,7 +213,7 @@ where
     ///
     /// The vocabulary size excludes subword units.
     pub fn len(&self) -> usize {
-        self.vocab.len()
+        self.vocab.words_len()
     }
 }
 

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -341,7 +341,9 @@ where
         // ndarray#474
         #[allow(clippy::deref_addrof)]
         let sims = similarity(
-            self.storage().view().slice(s![0..self.vocab().len(), ..]),
+            self.storage()
+                .view()
+                .slice(s![0..self.vocab().words_len(), ..]),
             embed.view(),
         );
 

--- a/src/subword.rs
+++ b/src/subword.rs
@@ -18,6 +18,9 @@ use crate::util::CollectWithCapacity;
 pub trait Indexer {
     /// Map an n-gram to an index in the subword embedding matrix.
     fn index_ngram(&self, ngram: &StrWithCharLen) -> u64;
+
+    /// Return the (exclusive) upper bound of this indexer.
+    fn upper_bound(&self) -> u64;
 }
 
 /// N-Gram indexer with bucketing.
@@ -107,6 +110,11 @@ where
         let mut hasher = H::default();
         ngram.hash(&mut hasher);
         hasher.finish() & self.mask
+    }
+
+    fn upper_bound(&self) -> u64 {
+        // max val is <= 64
+        2u64.pow(self.buckets_exp as u32)
     }
 }
 


### PR DESCRIPTION
Without the assertion, it is possible to construct `Embeddings` where the vocabulary can return out of bounds indices.