### PR TITLE
Update criterion dependency to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ toml = "0.5"
 approx = "0.3"
 maplit = "1"
 lazy_static = "1"
-criterion = "0.2"
+criterion = "0.3"
 
 [[bench]]
 name = "subword"

--- a/benches/subword.rs
+++ b/benches/subword.rs
@@ -18,7 +18,7 @@ fn subwords(string: &str, min_n: usize, max_n: usize, indexer: &impl Indexer) ->
 }
 
 fn ngrams_benchmark(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let rng = thread_rng();
     let string = rng
         .sample_iter(&Alphanumeric)
         .take(WORD_LENGTH)


### PR DESCRIPTION
As a side-effect, we are only dependent on one version of the rand
crate.