### PR TITLE
Support alignment of embedding matrices on 16-byte boundaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.32.0
+  - 1.36.0
   - stable
 before_script:
   - rustup component add clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,12 @@ exclude = [
 
 [dependencies]
 byteorder = "1"
+cfg-if = "0.1"
 fnv = "1"
 itertools = "0.8"
 memmap = "0.7"
 ndarray = "0.12"
+num-traits = "*"
 ordered-float = "1"
 rand = "0.7"
 rand_xorshift = "0.2"
@@ -40,3 +42,7 @@ criterion = "0.3"
 name = "subword"
 harness = false
 
+[features]
+align16 = []
+align32 = []
+align64 = []

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,11 +2,17 @@
 
 set -ex
 
-cargo build
-cargo test
+cargo build --verbose
+cargo test --verbose
+
+# Modern glibc versions align on 16 byte boundaries, so align on
+# 32-byte boundaries to shake out errors. Unfortunately, these
+# errors can be non-deterministic (accidental allocation on a
+# boundary).
+cargo test --verbose --features "align64"
 
 # On Rust 1.32.0, we only care about passing tests.
-if rustc --version | grep -v "^rustc 1.32.0"; then
+if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
   cargo fmt --all -- --check
   cargo clippy -- -D warnings
 fi

--- a/src/align.rs
+++ b/src/align.rs
@@ -1,0 +1,260 @@
+use std::alloc::{alloc, Layout};
+use std::fmt;
+use std::iter;
+use std::marker::PhantomData;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+
+use cfg_if::cfg_if;
+use ndarray::{Array, Array1, Dimension, Ix1, Ix2, ShapeBuilder, ShapeError, StrideShape};
+use num_traits::Zero;
+
+cfg_if! {
+    if #[cfg(feature = "align16")] {
+        pub type DefaultAlignment = Align16;
+    } else if #[cfg(feature = "align32")] {
+        pub type DefaultAlignment = Align32;
+    } else if #[cfg(feature = "align64")] {
+        pub type DefaultAlignment = Align64;
+    } else {
+        pub type DefaultAlignment = f32;
+    }
+}
+
+/// `AlignedArray` construction errors.
+#[derive(Debug, PartialEq)]
+pub enum AlignedArrayError {
+    /// The provided data has an incorrect alignment.
+    IncorrectAlignment,
+
+    /// ndarray shape error.
+    Shape(ShapeError),
+}
+
+impl fmt::Display for AlignedArrayError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::AlignedArrayError::*;
+        match *self {
+            IncorrectAlignment => write!(f, "Input array has incorrect alignment"),
+            Shape(ref err) => err.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for AlignedArrayError {
+    fn description(&self) -> &str {
+        use self::AlignedArrayError::*;
+
+        match *self {
+            IncorrectAlignment => "Input array has incorrect alignment",
+            Shape(ref err) => err.description(),
+        }
+    }
+}
+
+/// Matrix with alignment on a boundary that is a multiple of the size
+/// of type `Align`.
+pub type AlignedArray2<Align, A> = AlignedArray<Align, A, Ix2>;
+
+/// Wrapper for ndarray's `Array` that guarantees alignment on a
+/// boundary that is a multiple of the size of the type `Align`.
+pub struct AlignedArray<Align, A, D>
+where
+    D: Dimension,
+{
+    inner: Array<A, D>,
+    _phantom: PhantomData<Align>,
+}
+
+impl<Align, A> AlignedArray<Align, A, Ix1> {
+    /// Construct an `AlignedArray` from a `Vec`.
+    ///
+    /// This constructor fails when `data` is not aligned on a
+    /// boundary that is a multiple of the size of `Align`.
+    pub fn from_vec(data: Vec<A>) -> Result<Self, AlignedArrayError> {
+        if data.as_ptr().align_offset(mem::align_of::<Align>()) != 0 {
+            return Err(AlignedArrayError::IncorrectAlignment);
+        }
+
+        Ok(AlignedArray {
+            inner: Array1::from_vec(data),
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<Align, A, D> AlignedArray<Align, A, D>
+where
+    D: Dimension,
+{
+    /// Construct an `AlignedArray`, filled with an element.
+    ///
+    /// This constructor creates an `AlignedArray` of shape `shape`,
+    /// filled with `elem`, aligned on a boundary that is a multiple
+    /// of the size of `Align`.
+    pub fn from_elem<Sh>(shape: Sh, elem: A) -> Self
+    where
+        A: Clone + Zero,
+        Sh: ShapeBuilder<Dim = D>,
+    {
+        let shape = shape.into_shape();
+
+        let mut v = Vec::with_capacity_aligned::<Align>(shape.size());
+        v.extend(iter::repeat(elem).take(shape.size()));
+
+        AlignedArray {
+            inner: Array::from_shape_vec(shape, v)
+                .map_err(AlignedArrayError::Shape)
+                .expect("Shape mismatch"),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Construct an `AlignedArray` from a `Vec`.
+    ///
+    /// This constructor crates an `AlignedArray`, using `data` as
+    /// the backing storage with shape `shape`.
+    ///
+    /// Construction failes fails when `data` is not aligned on a
+    /// boundary that is a multiple of the size of `Align`.
+    pub fn from_shape_vec<Sh>(shape: Sh, data: Vec<A>) -> Result<Self, AlignedArrayError>
+    where
+        Sh: Into<StrideShape<D>>,
+    {
+        if data.as_ptr().align_offset(mem::align_of::<Align>()) != 0 {
+            return Err(AlignedArrayError::IncorrectAlignment);
+        }
+
+        Ok(AlignedArray {
+            inner: Array::from_shape_vec(shape, data).map_err(AlignedArrayError::Shape)?,
+            _phantom: PhantomData,
+        })
+    }
+
+    /// Construct an `AlignedArray`, filled with zeros.
+    ///
+    /// This constructor creates an `AlignedArray` of shape `shape`,
+    /// filled with zeros, aligned on a boundary that is a multiple of
+    /// the size of `Align`.
+    pub fn zeros<Sh>(shape: Sh) -> Self
+    where
+        A: Clone + Zero,
+        Sh: ShapeBuilder<Dim = D>,
+    {
+        Self::from_elem(shape, A::zero())
+    }
+}
+
+impl<Align, A, D> Deref for AlignedArray<Align, A, D>
+where
+    D: Dimension,
+{
+    type Target = Array<A, D>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<Align, A, D> DerefMut for AlignedArray<Align, A, D>
+where
+    D: Dimension,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<Align, A, D> fmt::Debug for AlignedArray<Align, A, D>
+where
+    A: fmt::Debug,
+    D: Dimension,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "AlignedArrayError {{ inner: {:?}}}", self.inner)
+    }
+}
+
+/// Allocate an array type with aligned memory.
+pub trait WithCapacityAligned<T> {
+    /// Allocate an array type with aligned memory.
+    ///
+    /// The type with the length `capacity` is aligned on a boundary
+    /// that is a multiple of the size of `Align`.
+    fn with_capacity_aligned<Align>(capacity: usize) -> Self;
+}
+
+impl<T> WithCapacityAligned<T> for Vec<T> {
+    fn with_capacity_aligned<Align>(capacity: usize) -> Self {
+        // alloc() beheviour is undefined for zero-sized layouts.
+        if capacity == 0 {
+            return Vec::with_capacity(0);
+        }
+
+        let align_size = mem::size_of::<Align>();
+        let type_size = mem::size_of::<T>();
+
+        let layout = Layout::from_size_align(capacity * type_size, align_size).unwrap();
+
+        // Allocate and wrap.
+        unsafe {
+            let p = alloc(layout);
+            Vec::from_raw_parts(p as *mut T, 0, capacity)
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[repr(align(16))]
+pub struct Align16 {
+    _data: [u8; 16],
+}
+
+#[cfg(feature = "align32")]
+#[repr(align(32))]
+pub struct Align32 {
+    _data: [u8; 32],
+}
+
+#[allow(dead_code)]
+#[repr(align(64))]
+pub struct Align64 {
+    _data: [u8; 64],
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem;
+
+    use super::{Align64, AlignedArray2, AlignedArrayError, WithCapacityAligned};
+
+    #[test]
+    fn test_aligned_64() {
+        // Test various capacity sizes.
+        for cap in 0..100 {
+            let t: Vec<f32> = Vec::with_capacity_aligned::<Align64>(cap);
+            assert_eq!(t.capacity(), cap);
+            if cap != 0 {
+                assert_eq!(t.as_ptr().align_offset(mem::align_of::<Align64>()), 0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_aligned_array_from_vec() {
+        // Assuming a probability of accidental correct alignment of
+        // 1/64, do some iterations to make accidental alignment throughout
+        // all iterations extremely unlikely (7.5e-37).
+        //
+        // Collect rather than panicking, so that we can check whether the
+        // correct error is used.
+        let result: Result<Vec<AlignedArray2<Align64, _>>, _> = (0..20)
+            .map(|_| {
+                let data = vec![0f32; 1];
+                AlignedArray2::from_shape_vec((1, 1), data)
+            })
+            .collect();
+
+        assert_eq!(result.unwrap_err(), AlignedArrayError::IncorrectAlignment);
+    }
+}

--- a/src/chunks/storage/quantized.rs
+++ b/src/chunks/storage/quantized.rs
@@ -597,9 +597,9 @@ mod tests {
     use std::io::{BufReader, Cursor, Read, Seek, SeekFrom};
 
     use byteorder::{LittleEndian, ReadBytesExt};
-    use ndarray::Array2;
     use reductive::pq::PQ;
 
+    use crate::align::AlignedArray2;
     use crate::chunks::io::{MmapChunk, ReadChunk, WriteChunk};
     use crate::chunks::storage::{MmapQuantizedArray, NdArray, Quantize, QuantizedArray, Storage};
 
@@ -607,11 +607,14 @@ mod tests {
     const N_COLS: usize = 100;
 
     fn test_ndarray() -> NdArray {
-        let test_data = Array2::from_shape_fn((N_ROWS, N_COLS), |(r, c)| {
-            r as f32 * N_COLS as f32 + c as f32
-        });
+        let mut matrix = AlignedArray2::zeros((N_ROWS, N_COLS));
+        for r in 0..N_ROWS {
+            for c in 0..N_COLS {
+                matrix[[r, c]] = r as f32 * N_COLS as f32 + c as f32;
+            }
+        }
 
-        NdArray::new(test_data)
+        NdArray::new(matrix)
     }
 
     fn test_quantized_array(norms: bool) -> QuantizedArray {

--- a/src/compat/fasttext/io.rs
+++ b/src/compat/fasttext/io.rs
@@ -1,10 +1,11 @@
 use std::io::BufRead;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use ndarray::{s, Array2, ErrorKind as ShapeErrorKind, ShapeError};
+use ndarray::{s, ErrorKind as ShapeErrorKind, ShapeError};
 use serde::Serialize;
 use toml::Value;
 
+use crate::align::AlignedArray2;
 use crate::chunks::metadata::Metadata;
 use crate::chunks::norms::NdNorms;
 use crate::chunks::storage::{NdArray, Storage, StorageViewMut};
@@ -287,14 +288,16 @@ where
         .read_u64::<LittleEndian>()
         .map_err(|e| ErrorKind::io_error("Cannot read number of embedding matrix columns", e))?;
 
-    let mut data = vec![0.0; (m * n) as usize];
+    let mut matrix = AlignedArray2::zeros((m as usize, n as usize));
     reader
-        .read_f32_into::<LittleEndian>(&mut data)
+        .read_f32_into::<LittleEndian>(
+            matrix
+                .as_slice_mut()
+                .expect("Non-contiguous memory in embedding matrix"),
+        )
         .map_err(|e| ErrorKind::io_error("Cannot read embeddings", e))?;
 
-    let data = Array2::from_shape_vec((m as usize, n as usize), data).map_err(Error::Shape)?;
-
-    Ok(NdArray::new(data))
+    Ok(NdArray::new(matrix))
 }
 
 /// Read the vocabulary.

--- a/src/compat/text.rs
+++ b/src/compat/text.rs
@@ -30,11 +30,11 @@
 //! let embedding = embeddings.embedding("Berlin");
 //! ```
 
-use std::io::{BufRead, Write};
+use std::io::{BufRead, Seek, SeekFrom, Write};
 
 use itertools::Itertools;
-use ndarray::Array2;
 
+use crate::align::{AlignedArray2, DefaultAlignment, WithCapacityAligned};
 use crate::chunks::norms::NdNorms;
 use crate::chunks::storage::{CowArray, NdArray, Storage, StorageViewMut};
 use crate::chunks::vocab::{SimpleVocab, Vocab};
@@ -68,7 +68,7 @@ where
 
 impl<R> ReadText<R> for Embeddings<SimpleVocab, NdArray>
 where
-    R: BufRead,
+    R: BufRead + Seek,
 {
     fn read_text(reader: &mut R) -> Result<Self> {
         let (_, vocab, mut storage, _) = Self::read_text_raw(reader, false)?.into_parts();
@@ -96,11 +96,30 @@ where
 
 impl<R> ReadTextRaw<R> for Embeddings<SimpleVocab, NdArray>
 where
-    R: BufRead,
+    R: BufRead + Seek,
 {
     fn read_text_raw(reader: &mut R, lossy: bool) -> Result<Self> {
-        read_embeds(reader, None, lossy)
+        let (vocab_len, embed_len) = text_embeds_dims(reader)?;
+        reader.seek(SeekFrom::Start(0)).map_err(|e| {
+            ErrorKind::io_error("Cannot seek to the start of the embedding file", e)
+        })?;
+        read_embeds_dims(reader, (vocab_len, embed_len), lossy)
     }
+}
+
+pub fn text_embeds_dims<R>(reader: &mut R) -> Result<(usize, usize)>
+where
+    R: BufRead + Seek,
+{
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .map_err(|e| ErrorKind::io_error("Cannot read line from embedding file", e))?;
+    let embed_size = line.split_whitespace().count() - 1;
+
+    let n_words = 1 + reader.lines().count();
+
+    Ok((n_words, embed_size))
 }
 
 /// Method to construct `Embeddings` from a text file with dimensions.
@@ -174,33 +193,29 @@ where
         let n_words = read_number(reader, b' ')?;
         let embed_len = read_number(reader, b'\n')?;
 
-        read_embeds(reader, Some((n_words, embed_len)), false)
+        read_embeds_dims(reader, (n_words, embed_len), false)
     }
 
     fn read_text_dims_raw_lossy(reader: &mut R) -> Result<Self> {
         let n_words = read_number(reader, b' ')?;
         let embed_len = read_number(reader, b'\n')?;
 
-        read_embeds(reader, Some((n_words, embed_len)), true)
+        read_embeds_dims(reader, (n_words, embed_len), true)
     }
 }
 
-fn read_embeds<R>(
+fn read_embeds_dims<R>(
     reader: &mut R,
-    shape: Option<(usize, usize)>,
+    shape: (usize, usize),
     lossy: bool,
 ) -> Result<Embeddings<SimpleVocab, NdArray>>
 where
     R: BufRead,
 {
-    let (mut words, mut data) = if let Some((n_words, dims)) = shape {
-        (
-            Vec::with_capacity(n_words),
-            Vec::with_capacity(n_words * dims),
-        )
-    } else {
-        (Vec::new(), Vec::new())
-    };
+    let (n_words, dims) = shape;
+
+    let mut words = Vec::with_capacity(n_words);
+    let mut data = Vec::with_capacity_aligned::<DefaultAlignment>(n_words * dims);
 
     loop {
         let mut buf = Vec::new();
@@ -240,32 +255,25 @@ where
         }
     }
 
-    let shape = if let Some((n_words, dims)) = shape {
-        if words.len() != n_words {
-            return Err(ErrorKind::Format(format!(
-                "Incorrect vocabulary size, expected: {}, got: {}",
-                n_words,
-                words.len()
-            ))
-            .into());
-        }
+    if words.len() != n_words {
+        return Err(ErrorKind::Format(format!(
+            "Incorrect vocabulary size, expected: {}, got: {}",
+            n_words,
+            words.len()
+        ))
+        .into());
+    }
 
-        if data.len() / n_words != dims {
-            return Err(ErrorKind::Format(format!(
-                "Incorrect embedding dimensionality, expected: {}, got: {}",
-                dims,
-                data.len() / n_words,
-            ))
-            .into());
-        };
-
-        (n_words, dims)
-    } else {
-        let dims = data.len() / words.len();
-        (words.len(), dims)
+    if data.len() / n_words != dims {
+        return Err(ErrorKind::Format(format!(
+            "Incorrect embedding dimensionality, expected: {}, got: {}",
+            dims,
+            data.len() / n_words,
+        ))
+        .into());
     };
 
-    let matrix = Array2::from_shape_vec(shape, data).map_err(Error::Shape)?;
+    let matrix = AlignedArray2::from_shape_vec(shape, data).map_err(Error::AlignedArray)?;
 
     Ok(Embeddings::new_without_norms(
         None,

--- a/src/compat/word2vec.rs
+++ b/src/compat/word2vec.rs
@@ -24,8 +24,9 @@ use std::mem;
 use std::slice::from_raw_parts_mut;
 
 use byteorder::{LittleEndian, WriteBytesExt};
-use ndarray::{Array2, Axis};
+use ndarray::Axis;
 
+use crate::align::AlignedArray2;
 use crate::chunks::norms::NdNorms;
 use crate::chunks::storage::{CowArray, NdArray, Storage, StorageViewMut};
 use crate::chunks::vocab::{SimpleVocab, Vocab};
@@ -92,7 +93,7 @@ where
         let n_words = read_number(reader, b' ')?;
         let embed_len = read_number(reader, b'\n')?;
 
-        let mut matrix = Array2::zeros((n_words, embed_len));
+        let mut matrix = AlignedArray2::zeros((n_words, embed_len));
         let mut words = Vec::with_capacity(n_words);
 
         for idx in 0..n_words {

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -516,6 +516,7 @@ mod tests {
     use toml::toml;
 
     use super::Embeddings;
+    use crate::align::{AlignedArray2, DefaultAlignment, WithCapacityAligned};
     use crate::chunks::metadata::Metadata;
     use crate::chunks::norms::NdNorms;
     use crate::chunks::storage::{MmapArray, NdArray, StorageView};
@@ -553,7 +554,9 @@ mod tests {
     #[test]
     fn norms() {
         let vocab = SimpleVocab::new(vec!["norms".to_string(), "test".to_string()]);
-        let storage = NdArray::new(array![[1f32], [-1f32]]);
+        let mut data = Vec::with_capacity_aligned::<DefaultAlignment>(2);
+        data.extend(&[1f32, -1f32]);
+        let storage = NdArray::new(AlignedArray2::from_shape_vec((2, 1), data).unwrap());
         let norms = NdNorms(array![2f32, 3f32]);
         let check = Embeddings::new(None, vocab, storage, norms);
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -13,12 +13,17 @@ use std::io::{BufReader, Read, Seek, Write};
 
 use ndarray::ShapeError;
 
+use crate::align::AlignedArrayError;
+
 /// `Result` type alias for operations that can lead to I/O errors.
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// I/O errors in reading or writing embeddings.
 #[derive(Debug)]
 pub enum Error {
+    /// Aligned array error error.
+    AlignedArray(AlignedArrayError),
+
     /// finalfusion errors.
     FinalFusion(ErrorKind),
 
@@ -31,6 +36,7 @@ impl fmt::Display for Error {
         use self::Error::*;
         match *self {
             FinalFusion(ref kind) => kind.fmt(f),
+            AlignedArray(ref err) => err.fmt(f),
             Shape(ref err) => err.fmt(f),
         }
     }
@@ -43,6 +49,7 @@ impl std::error::Error for Error {
         match *self {
             FinalFusion(ErrorKind::Format(ref desc)) => desc,
             FinalFusion(ErrorKind::Io { ref desc, .. }) => desc,
+            AlignedArray(ref err) => err.description(),
             Shape(ref err) => err.description(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,4 +68,6 @@ pub mod similarity;
 
 pub mod subword;
 
+pub(crate) mod align;
+
 pub(crate) mod util;


### PR DESCRIPTION
I spent a fair amount of time to implement this properly (everything gated through a special `AlignedArray` type, which has constructors guaranteeing alignment).

On CI enabled tests using 32-byte alignment. Recent glibc versions allocate on 16-byte boundaries, so tests would never fail on my machone, even when the code was wrong. But even with 32-byte boundaries there is some non-determinism, since there is a small chance that memory that is not explicitly aligned ended up on a boundary by chance.

Advantages:

- We have explicit control over alignment.
- By using feature gating, we can use default (f32) alignment as before.
- We can give other libraries (Eigen, Tensorflow) the alignment that they need.

Disadvantages:

- As discussed, reading text files without dimensions, no requires two passes over the file.
- We have to be very careful with new code to use `Vec::with_capacity_aligned` if an embedding matrix is initialized from a `Vec`.
- Apart from non-determinism, we might miss cases where alignment is not enforced, when the code path is not covered by a unit test (I just did a grep for `vec!` and `Vec::with_capacity`).