### PR TITLE
Add NGram Indexer.

### DIFF
--- a/src/chunks/vocab.rs
+++ b/src/chunks/vocab.rs
@@ -515,19 +515,24 @@ impl Vocab for VocabWrap {
 pub trait NGramIndices {
     /// Return the subword ngrams and their indices of a word,
     /// in the subword vocabulary.
-    fn ngram_indices(&self, word: &str) -> Option<Vec<(String, usize)>>;
+    fn ngram_indices(&self, word: &str) -> Option<Vec<(String, Option<usize>)>>;
 }
 
 impl<I> NGramIndices for SubwordVocab<I>
 where
     I: Clone + Indexer,
 {
-    fn ngram_indices(&self, word: &str) -> Option<Vec<(String, usize)>> {
+    fn ngram_indices(&self, word: &str) -> Option<Vec<(String, Option<usize>)>> {
         let indices = Self::bracket(word)
             .as_str()
             .ngrams_indices(self.min_n as usize, self.max_n as usize, &self.indexer)
             .into_iter()
-            .map(|(ngram, idx)| (ngram.to_owned(), idx as usize + self.words_len()))
+            .map(|(ngram, idx)| {
+                (
+                    ngram.to_owned(),
+                    idx.map(|idx| idx as usize + self.words_len()),
+                )
+            })
             .collect::<Vec<_>>();
         if indices.is_empty() {
             None

--- a/src/compat/fasttext/indexer.rs
+++ b/src/compat/fasttext/indexer.rs
@@ -41,8 +41,8 @@ impl BucketIndexer for FastTextIndexer {
 }
 
 impl Indexer for FastTextIndexer {
-    fn index_ngram(&self, ngram: &StrWithCharLen) -> u64 {
-        u64::from(fasttext_hash(ngram.as_str()) % self.buckets)
+    fn index_ngram(&self, ngram: &StrWithCharLen) -> Option<u64> {
+        Some(u64::from(fasttext_hash(ngram.as_str()) % self.buckets))
     }
 
     fn upper_bound(&self) -> u64 {


### PR DESCRIPTION
This commit adds an NGramIndexer with explicitly stored ngrams.
Returning an index through index_ngram is now optional.