### PR TITLE
Add SubwordVocab with NGramIndexer.

### DIFF
--- a/src/chunks/io.rs
+++ b/src/chunks/io.rs
@@ -21,6 +21,7 @@ pub enum ChunkIdentifier {
     Metadata = 5,
     NdNorms = 6,
     FastTextSubwordVocab = 7,
+    FinalfusionNGramVocab = 8,
 }
 
 impl ChunkIdentifier {
@@ -35,6 +36,7 @@ impl ChunkIdentifier {
             5 => Some(Metadata),
             6 => Some(NdNorms),
             7 => Some(FastTextSubwordVocab),
+            8 => Some(FinalfusionNGramVocab),
             _ => None,
         }
     }
@@ -71,6 +73,7 @@ impl Display for ChunkIdentifier {
             SimpleVocab => write!(f, "SimpleVocab"),
             NdArray => write!(f, "NdArray"),
             FastTextSubwordVocab => write!(f, "FastTextSubwordVocab"),
+            FinalfusionNGramVocab => write!(f, "FinalfusionNGramVocab"),
             FinalfusionSubwordVocab => write!(f, "FinalfusionSubwordVocab"),
             QuantizedArray => write!(f, "QuantizedArray"),
             Metadata => write!(f, "Metadata"),


### PR DESCRIPTION
Implement read and write methods for new vocab type.

I factored out read and write methods for words & ngrams since there'd be a lot of duplicates of that.

A new variant to `VocabWrap` would come in with the next PR, enabling full support for explicit ngram vocabs.