### PR TITLE
Support alignment of embeddings on 16/32/64-byte boundaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.32.0
+  - 1.36.0
   - stable
 before_script:
   - rustup component add clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,12 @@ exclude = [
 
 [dependencies]
 byteorder = "1"
+cfg-if = "0.1"
 fnv = "1"
 itertools = "0.8"
 memmap = "0.7"
 ndarray = "0.12"
+num-traits = "*"
 ordered-float = "1"
 rand = "0.7"
 rand_xorshift = "0.2"
@@ -40,3 +42,7 @@ criterion = "0.3"
 name = "subword"
 harness = false
 
+[features]
+align16 = []
+align32 = []
+align64 = []

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,11 +2,17 @@
 
 set -ex
 
-cargo build
-cargo test
+cargo build --verbose
+cargo test --verbose
+
+# Modern glibc versions align on 16 byte boundaries, so align on
+# 32-byte boundaries to shake out errors. Unfortunately, these
+# errors can be non-deterministic (accidental allocation on a
+# boundary).
+cargo test --verbose --features "align64"
 
 # On Rust 1.32.0, we only care about passing tests.
-if rustc --version | grep -v "^rustc 1.32.0"; then
+if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
   cargo fmt --all -- --check
   cargo clippy -- -D warnings
 fi

--- a/src/align.rs
+++ b/src/align.rs
@@ -1,0 +1,253 @@
+use std::alloc::{alloc, Layout};
+use std::fmt;
+use std::iter;
+use std::marker::PhantomData;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+
+use cfg_if::cfg_if;
+use ndarray::{Array, Ix2, ShapeBuilder, ShapeError};
+use num_traits::Zero;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct MatrixLayout<Align, A> {
+    rows: usize,
+    cols: usize,
+    _align_phantom: PhantomData<Align>,
+    _data_phantom: PhantomData<A>,
+}
+
+impl<Align, A> fmt::Debug for MatrixLayout<Align, A> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "MatrixLayout {{ rows: {:?}, cols: {:?}}}",
+            self.rows, self.cols
+        )
+    }
+}
+
+impl<Align, A> MatrixLayout<Align, A> {
+    pub fn new(rows: usize, cols: usize) -> Self {
+        assert!(
+            mem::size_of::<Align>() % mem::size_of::<A>() == 0,
+            "Alignment should be multiple of data type"
+        );
+
+        MatrixLayout {
+            rows,
+            cols,
+            _align_phantom: PhantomData,
+            _data_phantom: PhantomData,
+        }
+    }
+
+    /// Array shape with padding.
+    pub fn shape_with_padding(&self) -> [usize; 2] {
+        // The number of A that fits in an Align.
+        let data_per_align = mem::size_of::<Align>() / mem::size_of::<A>();
+
+        // Round up to get the padded length.
+        let padded_len = (self.cols + data_per_align - 1) & !(data_per_align - 1);
+
+        [self.rows, padded_len]
+    }
+
+    /// Shape without padding.
+    pub fn shape_without_padding(&self) -> [usize; 2] {
+        [self.rows, self.cols]
+    }
+}
+
+cfg_if! {
+    if #[cfg(feature = "align16")] {
+        pub type DefaultAlignment = Align16;
+    } else if #[cfg(feature = "align32")] {
+        pub type DefaultAlignment = Align32;
+    } else if #[cfg(feature = "align64")] {
+        pub type DefaultAlignment = Align64;
+    } else {
+        pub type DefaultAlignment = f32;
+    }
+}
+
+/// `AlignedMatrix` construction errors.
+#[derive(Debug, PartialEq)]
+pub enum AlignedMatrixError {
+    /// The provided data has an incorrect alignment.
+    IncorrectAlignment,
+
+    /// ndarray shape error.
+    Shape(ShapeError),
+}
+
+impl fmt::Display for AlignedMatrixError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::AlignedMatrixError::*;
+        match *self {
+            IncorrectAlignment => write!(f, "Input array has incorrect alignment"),
+            Shape(ref err) => err.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for AlignedMatrixError {
+    fn description(&self) -> &str {
+        use self::AlignedMatrixError::*;
+
+        match *self {
+            IncorrectAlignment => "Input array has incorrect alignment",
+            Shape(ref err) => err.description(),
+        }
+    }
+}
+
+/// Wrapper for ndarray's `Array` that guarantees alignment on a
+/// boundary that is a multiple of the size of the type `Align`.
+pub struct AlignedMatrix<Align, A> {
+    inner: Array<A, Ix2>,
+    _phantom: PhantomData<Align>,
+}
+
+impl<Align, A> AlignedMatrix<Align, A> {
+    /// Construct an `AlignedMatrix`, filled with an element.
+    ///
+    /// This constructor creates an `AlignedMatrix` of shape `shape`,
+    /// filled with `elem`, aligned on a boundary that is a multiple
+    /// of the size of `Align`.
+    pub fn from_elem(layout: MatrixLayout<Align, A>, elem: A) -> Self
+    where
+        A: Clone + Zero,
+    {
+        let shape = layout.shape_with_padding().into_shape();
+
+        let mut v = Vec::with_capacity_aligned::<Align>(shape.size());
+        v.extend(iter::repeat(elem).take(shape.size()));
+
+        AlignedMatrix {
+            inner: Array::from_shape_vec(shape, v)
+                .map_err(AlignedMatrixError::Shape)
+                .expect("Shape mismatch"),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Construct an `AlignedMatrix`, filled with zeros.
+    ///
+    /// This constructor creates an `AlignedMatrix` of shape `shape`,
+    /// filled with zeros, aligned on a boundary that is a multiple of
+    /// the size of `Align`.
+    pub fn zeros(layout: MatrixLayout<Align, A>) -> Self
+    where
+        A: Clone + Zero,
+    {
+        Self::from_elem(layout, A::zero())
+    }
+}
+
+impl<Align, A> Deref for AlignedMatrix<Align, A> {
+    type Target = Array<A, Ix2>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<Align, A> DerefMut for AlignedMatrix<Align, A> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<Align, A> fmt::Debug for AlignedMatrix<Align, A>
+where
+    A: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "AlignedMatrixError {{ inner: {:?}}}", self.inner)
+    }
+}
+
+/// Allocate an array type with aligned memory.
+trait WithCapacityAligned<T> {
+    /// Allocate an array type with aligned memory.
+    ///
+    /// The type with the length `capacity` is aligned on a boundary
+    /// that is a multiple of the size of `Align`.
+    fn with_capacity_aligned<Align>(capacity: usize) -> Self;
+}
+
+impl<T> WithCapacityAligned<T> for Vec<T> {
+    fn with_capacity_aligned<Align>(capacity: usize) -> Self {
+        // alloc() beheviour is undefined for zero-sized layouts.
+        if capacity == 0 {
+            return Vec::with_capacity(0);
+        }
+
+        let align_size = mem::size_of::<Align>();
+        let type_size = mem::size_of::<T>();
+
+        let layout = Layout::from_size_align(capacity * type_size, align_size).unwrap();
+
+        // Allocate and wrap.
+        unsafe {
+            let p = alloc(layout);
+            Vec::from_raw_parts(p as *mut T, 0, capacity)
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[repr(align(16))]
+#[derive(Clone, Copy)]
+pub struct Align16 {
+    _data: [u8; 16],
+}
+
+#[cfg(feature = "align32")]
+#[repr(align(32))]
+#[derive(Clone, Copy)]
+pub struct Align32 {
+    _data: [u8; 32],
+}
+
+#[allow(dead_code)]
+#[repr(align(64))]
+#[derive(Clone, Copy)]
+pub struct Align64 {
+    _data: [u8; 64],
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem;
+
+    use super::{Align64, MatrixLayout, WithCapacityAligned};
+
+    #[test]
+    fn test_array_layout_4() {
+        let layout: MatrixLayout<f32, f32> = MatrixLayout::new(10, 100);
+        assert_eq!(layout.shape_with_padding(), [10, 100]);
+    }
+
+    #[test]
+    fn test_array_layout_64() {
+        let layout: MatrixLayout<Align64, f32> = MatrixLayout::new(10, 100);
+        assert_eq!(layout.shape_with_padding(), [10, 112]);
+
+        let layout: MatrixLayout<Align64, f32> = MatrixLayout::new(10, 32);
+        assert_eq!(layout.shape_with_padding(), [10, 32]);
+    }
+
+    #[test]
+    fn test_aligned_64() {
+        // Test various capacity sizes.
+        for cap in 0..100 {
+            let t: Vec<f32> = Vec::with_capacity_aligned::<Align64>(cap);
+            assert_eq!(t.capacity(), cap);
+            if cap != 0 {
+                assert_eq!(t.as_ptr().align_offset(mem::align_of::<Align64>()), 0);
+            }
+        }
+    }
+}

--- a/src/chunks/storage/quantized.rs
+++ b/src/chunks/storage/quantized.rs
@@ -597,9 +597,9 @@ mod tests {
     use std::io::{BufReader, Cursor, Read, Seek, SeekFrom};
 
     use byteorder::{LittleEndian, ReadBytesExt};
-    use ndarray::Array2;
     use reductive::pq::PQ;
 
+    use crate::align::{AlignedMatrix, MatrixLayout};
     use crate::chunks::io::{MmapChunk, ReadChunk, WriteChunk};
     use crate::chunks::storage::{MmapQuantizedArray, NdArray, Quantize, QuantizedArray, Storage};
 
@@ -607,11 +607,15 @@ mod tests {
     const N_COLS: usize = 100;
 
     fn test_ndarray() -> NdArray {
-        let test_data = Array2::from_shape_fn((N_ROWS, N_COLS), |(r, c)| {
-            r as f32 * N_COLS as f32 + c as f32
-        });
+        let layout = MatrixLayout::new(N_ROWS, N_COLS);
+        let mut matrix = AlignedMatrix::zeros(layout);
+        for r in 0..N_ROWS {
+            for c in 0..N_COLS {
+                matrix[[r, c]] = r as f32 * N_COLS as f32 + c as f32;
+            }
+        }
 
-        NdArray::new(test_data)
+        NdArray::new(layout, matrix)
     }
 
     fn test_quantized_array(norms: bool) -> QuantizedArray {

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -516,6 +516,7 @@ mod tests {
     use toml::toml;
 
     use super::Embeddings;
+    use crate::align::{AlignedMatrix, MatrixLayout};
     use crate::chunks::metadata::Metadata;
     use crate::chunks::norms::NdNorms;
     use crate::chunks::storage::{MmapArray, NdArray, StorageView};
@@ -553,7 +554,11 @@ mod tests {
     #[test]
     fn norms() {
         let vocab = SimpleVocab::new(vec!["norms".to_string(), "test".to_string()]);
-        let storage = NdArray::new(array![[1f32], [-1f32]]);
+        let layout = MatrixLayout::new(2, 1);
+        let mut matrix = AlignedMatrix::zeros(layout);
+        matrix[[0, 0]] = 1f32;
+        matrix[[1, 0]] = -1f32;
+        let storage = NdArray::new(layout, matrix);
         let norms = NdNorms(array![2f32, 3f32]);
         let check = Embeddings::new(None, vocab, storage, norms);
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -13,12 +13,17 @@ use std::io::{BufReader, Read, Seek, Write};
 
 use ndarray::ShapeError;
 
+use crate::align::AlignedMatrixError;
+
 /// `Result` type alias for operations that can lead to I/O errors.
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// I/O errors in reading or writing embeddings.
 #[derive(Debug)]
 pub enum Error {
+    /// Aligned array error error.
+    AlignedMatrix(AlignedMatrixError),
+
     /// finalfusion errors.
     FinalFusion(ErrorKind),
 
@@ -31,6 +36,7 @@ impl fmt::Display for Error {
         use self::Error::*;
         match *self {
             FinalFusion(ref kind) => kind.fmt(f),
+            AlignedMatrix(ref err) => err.fmt(f),
             Shape(ref err) => err.fmt(f),
         }
     }
@@ -43,6 +49,7 @@ impl std::error::Error for Error {
         match *self {
             FinalFusion(ErrorKind::Format(ref desc)) => desc,
             FinalFusion(ErrorKind::Io { ref desc, .. }) => desc,
+            AlignedMatrix(ref err) => err.description(),
             Shape(ref err) => err.description(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,4 +68,6 @@ pub mod similarity;
 
 pub mod subword;
 
+pub(crate) mod align;
+
 pub(crate) mod util;


### PR DESCRIPTION
This is the variant with aligned embeddings. No full review necessary yet, I want to try/time this with some other code to see the impact.