### PR TITLE
Expose indexer and ngram range for subword vocabs.

### DIFF
--- a/src/chunks/vocab.rs
+++ b/src/chunks/vocab.rs
@@ -154,6 +154,21 @@ where
         }
     }
 
+    /// Get the vocab's indexer.
+    pub fn indexer(&self) -> &I {
+        &self.indexer
+    }
+
+    /// Get the lower bound of the generated ngram lengths.
+    pub fn min_n(&self) -> u32 {
+        self.min_n
+    }
+
+    /// Get the upper bound of the generated ngram lengths.
+    pub fn max_n(&self) -> u32 {
+        self.max_n
+    }
+
     fn bracket(word: impl AsRef<str>) -> String {
         let mut bracketed = String::new();
         bracketed.push(Self::BOW);

--- a/src/subword.rs
+++ b/src/subword.rs
@@ -172,7 +172,21 @@ pub struct StrWithCharLen<'a> {
     char_len: usize,
 }
 
+impl<'a> From<&'a str> for StrWithCharLen<'a> {
+    fn from(s: &'a str) -> Self {
+        StrWithCharLen::new(s)
+    }
+}
+
 impl<'a> StrWithCharLen<'a> {
+    /// Construct `StrWithCharLen`.
+    ///
+    /// Counts the number of chars in a `&str` and constructs a `StrWithCharLen` from it.
+    pub fn new(s: &'a str) -> Self {
+        let char_len = s.chars().count();
+        StrWithCharLen { inner: s, char_len }
+    }
+
     pub fn as_str(&self) -> &str {
         self.inner
     }


### PR DESCRIPTION
Being able index single NGrams would be nice. In order to do so, we also need to expose a constructor for `StrWithCharLen`.