### PR TITLE
Run clippy and fmt only on stable.

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -5,8 +5,8 @@ set -ex
 cargo build
 cargo test
 
-# On Rust 1.32.0, we only care about passing tests.
-if rustc --version | grep -v "^rustc 1.32.0"; then
+# Only run fmt and clippy against stable Rust 
+if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
   cargo fmt --all -- --check
   cargo clippy -- -D warnings
 fi


### PR DESCRIPTION
Clippy and fmt run against 1.37, too since we're doing a negative match on 1.32.