### PR TITLE
Encapsulate NdNorms array.

### DIFF
--- a/src/compat/fasttext/io.rs
+++ b/src/compat/fasttext/io.rs
@@ -96,7 +96,7 @@ impl ReadFastTextPrivate for Embeddings<FastTextSubwordVocab, NdArray> {
         let mut storage = read_embeddings(&mut reader)?;
         add_subword_embeddings(&vocab, &mut storage);
         #[allow(clippy::deref_addrof)]
-        let norms = NdNorms(l2_normalize_array(
+        let norms = NdNorms::new(l2_normalize_array(
             storage.view_mut().slice_mut(s![0..vocab.words_len(), ..]),
         ));
 

--- a/src/compat/text.rs
+++ b/src/compat/text.rs
@@ -74,14 +74,14 @@ where
         let (_, vocab, mut storage, _) = Self::read_text_raw(reader, false)?.into_parts();
         let norms = l2_normalize_array(storage.view_mut());
 
-        Ok(Embeddings::new(None, vocab, storage, NdNorms(norms)))
+        Ok(Embeddings::new(None, vocab, storage, NdNorms::new(norms)))
     }
 
     fn read_text_lossy(reader: &mut R) -> Result<Self> {
         let (_, vocab, mut storage, _) = Self::read_text_raw(reader, true)?.into_parts();
         let norms = l2_normalize_array(storage.view_mut());
 
-        Ok(Embeddings::new(None, vocab, storage, NdNorms(norms)))
+        Ok(Embeddings::new(None, vocab, storage, NdNorms::new(norms)))
     }
 }
 
@@ -140,14 +140,14 @@ where
         let (_, vocab, mut storage, _) = Self::read_text_dims_raw(reader)?.into_parts();
         let norms = l2_normalize_array(storage.view_mut());
 
-        Ok(Embeddings::new(None, vocab, storage, NdNorms(norms)))
+        Ok(Embeddings::new(None, vocab, storage, NdNorms::new(norms)))
     }
 
     fn read_text_dims_lossy(reader: &mut R) -> Result<Self> {
         let (_, vocab, mut storage, _) = Self::read_text_dims_raw_lossy(reader)?.into_parts();
         let norms = l2_normalize_array(storage.view_mut());
 
-        Ok(Embeddings::new(None, vocab, storage, NdNorms(norms)))
+        Ok(Embeddings::new(None, vocab, storage, NdNorms::new(norms)))
     }
 }
 

--- a/src/compat/word2vec.rs
+++ b/src/compat/word2vec.rs
@@ -62,7 +62,7 @@ where
             Embeddings::read_word2vec_binary_raw(reader, false)?.into_parts();
         let norms = l2_normalize_array(storage.view_mut());
 
-        Ok(Embeddings::new(None, vocab, storage, NdNorms(norms)))
+        Ok(Embeddings::new(None, vocab, storage, NdNorms::new(norms)))
     }
 
     fn read_word2vec_binary_lossy(reader: &mut R) -> Result<Self> {
@@ -70,7 +70,7 @@ where
             Embeddings::read_word2vec_binary_raw(reader, true)?.into_parts();
         let norms = l2_normalize_array(storage.view_mut());
 
-        Ok(Embeddings::new(None, vocab, storage, NdNorms(norms)))
+        Ok(Embeddings::new(None, vocab, storage, NdNorms::new(norms)))
     }
 }
 


### PR DESCRIPTION
Encapsulate NdNorms array, provide interface through deref to
Array1.

I also removed the `Norms` trait that I didn't even know existed before. I assume that was planned as a compatibility layer if we introduced other norm chunks. Now that we're planning to stabilize the API and don't intend to add new chunks and features I think this can go away until we'd have to break the API anyways. With only the `Norms` trait for accessing a norm, `NdNorms` is useless unless `Norms' is imported.