### PR TITLE
Encapsulate Metadata's data.

### DIFF
--- a/src/compat/fasttext/io.rs
+++ b/src/compat/fasttext/io.rs
@@ -112,7 +112,7 @@ impl ReadFastTextPrivate for Embeddings<FastTextSubwordVocab, NdArray> {
         })?;
 
         Ok(Embeddings::new(
-            Some(Metadata(metadata)),
+            Some(Metadata::new(metadata)),
             vocab,
             storage,
             norms,

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -536,7 +536,7 @@ mod tests {
     }
 
     fn test_metadata() -> Metadata {
-        Metadata(toml! {
+        Metadata::new(toml! {
             [hyperparameters]
             dims = 300
             ns = 5


### PR DESCRIPTION
Restrict interface to Metadata's data, impl Deref(Mut) with
target toml::Value for Metadata.