### PR TITLE
Ensure vocabs and explicit indexer don't contain duplicate words.

### DIFF
--- a/src/chunks/vocab/simple.rs
+++ b/src/chunks/vocab/simple.rs
@@ -19,9 +19,16 @@ impl SimpleVocab {
     /// Construct a new simple vocabulary.
     ///
     /// Words are assigned indices in the given order.
+    ///
+    /// Panics when there are duplicate words.
     pub fn new(words: impl Into<Vec<String>>) -> Self {
         let words = words.into();
         let indices = create_indices(&words);
+        assert_eq!(
+            words.len(),
+            indices.len(),
+            "words contained duplicate entries."
+        );
         SimpleVocab { words, indices }
     }
 }

--- a/src/chunks/vocab/subword.rs
+++ b/src/chunks/vocab/subword.rs
@@ -44,9 +44,16 @@ where
     /// Words are assigned indices in the given order. NGrams in range `(min_n..max_n)` are
     /// considered. The `indexer` is used to look up indices for the NGrams produced by this
     /// `SubwordVocab`.
+    ///
+    /// Panics when there are duplicate words.
     pub fn new(words: impl Into<Vec<String>>, min_n: u32, max_n: u32, indexer: I) -> Self {
         let words = words.into();
         let indices = create_indices(&words);
+        assert_eq!(
+            words.len(),
+            indices.len(),
+            "words contained duplicate entries."
+        );
 
         SubwordVocab {
             indices,

--- a/src/subword.rs
+++ b/src/subword.rs
@@ -141,6 +141,9 @@ impl ExplicitIndexer {
 }
 
 impl ExplicitIndexer {
+    /// Construct a new explicit indexer.
+    ///
+    /// Panics when there are duplicate ngrams.
     pub fn new<V>(ngrams: V) -> Self
     where
         V: Into<Vec<String>>,
@@ -152,6 +155,11 @@ impl ExplicitIndexer {
             .enumerate()
             .map(|(idx, ngram)| (ngram, idx as u64))
             .collect::<HashMap<String, u64>>();
+        assert_eq!(
+            index.len(),
+            ngrams.len(),
+            "ngrams contained duplicate entries."
+        );
         ExplicitIndexer { ngrams, index }
     }
 }


### PR DESCRIPTION
Add assertions to constructors to ensure that words are not
added twice.