### PR TITLE
Rename ChunkIdentifiers for vocabs.

### DIFF
--- a/src/chunks/io.rs
+++ b/src/chunks/io.rs
@@ -16,12 +16,12 @@ pub enum ChunkIdentifier {
     Header = 0,
     SimpleVocab = 1,
     NdArray = 2,
-    FinalfusionSubwordVocab = 3,
+    BucketSubwordVocab = 3,
     QuantizedArray = 4,
     Metadata = 5,
     NdNorms = 6,
     FastTextSubwordVocab = 7,
-    FinalfusionNGramVocab = 8,
+    ExplicitSubwordVocab = 8,
 }
 
 impl ChunkIdentifier {
@@ -31,12 +31,12 @@ impl ChunkIdentifier {
         match identifier {
             1 => Some(SimpleVocab),
             2 => Some(NdArray),
-            3 => Some(FinalfusionSubwordVocab),
+            3 => Some(BucketSubwordVocab),
             4 => Some(QuantizedArray),
             5 => Some(Metadata),
             6 => Some(NdNorms),
             7 => Some(FastTextSubwordVocab),
-            8 => Some(FinalfusionNGramVocab),
+            8 => Some(ExplicitSubwordVocab),
             _ => None,
         }
     }
@@ -73,8 +73,8 @@ impl Display for ChunkIdentifier {
             SimpleVocab => write!(f, "SimpleVocab"),
             NdArray => write!(f, "NdArray"),
             FastTextSubwordVocab => write!(f, "FastTextSubwordVocab"),
-            FinalfusionNGramVocab => write!(f, "FinalfusionNGramVocab"),
-            FinalfusionSubwordVocab => write!(f, "FinalfusionSubwordVocab"),
+            ExplicitSubwordVocab => write!(f, "ExplicitSubwordVocab"),
+            BucketSubwordVocab => write!(f, "BucketSubwordVocab"),
             QuantizedArray => write!(f, "QuantizedArray"),
             Metadata => write!(f, "Metadata"),
             NdNorms => write!(f, "NdNorms"),

--- a/src/chunks/vocab/subword.rs
+++ b/src/chunks/vocab/subword.rs
@@ -190,7 +190,7 @@ impl ReadChunk for BucketSubwordVocab {
     where
         R: Read + Seek,
     {
-        Self::read_bucketed_chunk(read, ChunkIdentifier::FinalfusionSubwordVocab)
+        Self::read_bucketed_chunk(read, ChunkIdentifier::BucketSubwordVocab)
     }
 }
 
@@ -199,7 +199,7 @@ impl ReadChunk for ExplicitSubwordVocab {
     where
         R: Read + Seek,
     {
-        Self::read_ngram_chunk(read, ChunkIdentifier::FinalfusionNGramVocab)
+        Self::read_ngram_chunk(read, ChunkIdentifier::ExplicitSubwordVocab)
     }
 }
 
@@ -218,7 +218,7 @@ impl WriteChunk for FastTextSubwordVocab {
 
 impl WriteChunk for BucketSubwordVocab {
     fn chunk_identifier(&self) -> ChunkIdentifier {
-        ChunkIdentifier::FinalfusionSubwordVocab
+        ChunkIdentifier::BucketSubwordVocab
     }
 
     fn write_chunk<W>(&self, write: &mut W) -> Result<()>
@@ -231,7 +231,7 @@ impl WriteChunk for BucketSubwordVocab {
 
 impl WriteChunk for ExplicitSubwordVocab {
     fn chunk_identifier(&self) -> ChunkIdentifier {
-        ChunkIdentifier::FinalfusionNGramVocab
+        ChunkIdentifier::ExplicitSubwordVocab
     }
 
     fn write_chunk<W>(&self, write: &mut W) -> Result<()>

--- a/src/chunks/vocab/wrappers.rs
+++ b/src/chunks/vocab/wrappers.rs
@@ -117,18 +117,18 @@ impl ReadChunk for VocabWrap {
             ChunkIdentifier::FastTextSubwordVocab => {
                 SubwordVocab::read_chunk(read).map(VocabWrap::FastTextSubwordVocab)
             }
-            ChunkIdentifier::FinalfusionSubwordVocab => {
+            ChunkIdentifier::BucketSubwordVocab => {
                 SubwordVocab::read_chunk(read).map(VocabWrap::BucketSubwordVocab)
             }
-            ChunkIdentifier::FinalfusionNGramVocab => {
+            ChunkIdentifier::ExplicitSubwordVocab => {
                 SubwordVocab::read_chunk(read).map(VocabWrap::ExplicitSubwordVocab)
             }
             _ => Err(ErrorKind::Format(format!(
                 "Invalid chunk identifier, expected one of: {}, {}, {} or {}, got: {}",
                 ChunkIdentifier::SimpleVocab,
-                ChunkIdentifier::FinalfusionNGramVocab,
+                ChunkIdentifier::ExplicitSubwordVocab,
                 ChunkIdentifier::FastTextSubwordVocab,
-                ChunkIdentifier::FinalfusionSubwordVocab,
+                ChunkIdentifier::BucketSubwordVocab,
                 chunk_id
             ))
             .into()),


### PR DESCRIPTION
Simple change, the `ChunkIdentifiers` didn't get their new names yet.