### PR TITLE
Write Norms' identifier in header.

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -359,6 +359,10 @@ where
             self.storage.chunk_identifier(),
         ]);
 
+        if let Some(ref norms) = self.norms {
+            chunks.push(norms.chunk_identifier());
+        }
+
         Header::new(chunks).write_chunk(write)?;
         if let Some(ref metadata) = self.metadata {
             metadata.write_chunk(write)?;


### PR DESCRIPTION
Write the chunkidentifier for NdNorms in the header if present.

Fixes #102 