### PR TITLE
Prepare 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "finalfusion"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2018"
-authors = ["Daniël de Kok <me@danieldk.eu>"]
+authors = ["Daniël de Kok <me@danieldk.eu>", "Sebastian Pütz <sebastian.puetz@student.uni-tuebingen.de>"]
 description = "Reader and writer for common word embedding formats"
 documentation = "https://docs.rs/finalfusion/"
-keywords = ["embeddings", "word2vec", "glove", "finalfusion", "subword"]
+keywords = ["embeddings", "word2vec", "glove", "finalfusion", "subword", "fasttext"]
 homepage = "https://github.com/finalfusion/finalfusion-rust"
 repository = "https://github.com/finalfusion/finalfusion-rust"
 # Use after SPDX list is updated

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Rust. `finalfusion` primarily works with
 variety of features. Additionally, the fastText, word2vec and GloVe file
 formats are also supported.
 
+`finalfusion` is API stable since 0.11.0. However, we cannot tag
+version 1 yet, because several dependencies that are exposed through
+the API have not reached version 1 (particularly `ndarray` and
+`rand`). Future 0.x releases of `finalfusion` will be used to accomodate
+updates of these dependencies.
+
 ## Usage
 
 To make `finalfusion` available in your crate, simply place the following


### PR DESCRIPTION
After uploading 0.11.0 to crates.io, I will set up [rust-semver](https://github.com/rust-dev-tools/rust-semverver) to add API checks to CI.

Great work everyone! :tada: :tada: :tada: 