### PR TITLE
Add derives to Embeddings and VocabWrap.

### DIFF
--- a/src/chunks/vocab/wrappers.rs
+++ b/src/chunks/vocab/wrappers.rs
@@ -19,7 +19,7 @@ use crate::io::{Error, ErrorKind, Result};
 /// all the vocabularies and storage types known to this crate such
 /// that the type `Embeddings<VocabWrap, StorageWrap>` covers all
 /// variations.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum VocabWrap {
     SimpleVocab(SimpleVocab),
     ExplicitSubwordVocab(ExplicitSubwordVocab),

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -30,7 +30,7 @@ use crate::util::l2_normalize;
 /// This data structure stores word embeddings (also known as *word vectors*)
 /// and provides some useful methods on the embeddings, such as similarity
 /// and analogy queries.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Embeddings<V, S> {
     metadata: Option<Metadata>,
     storage: S,


### PR DESCRIPTION
Derive Eq+PartialEq for VocabWrap and Clone for Embeddings.

____

All vocab types derive Eq + PartialEq, the wrapper should do the same. Additionally derive clone for embeddings as discussed in #87 