### PR TITLE
Keep benches updated

### DIFF
--- a/benches/array.rs
+++ b/benches/array.rs
@@ -2,8 +2,8 @@ use std::fs::File;
 use std::io::BufReader;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use finalfusion::chunks::vocab::WordIndex;
 use finalfusion::prelude::*;
+use finalfusion::vocab::{Vocab, WordIndex};
 
 mod data;
 use data::load_corpus;

--- a/benches/quantized.rs
+++ b/benches/quantized.rs
@@ -2,8 +2,8 @@ use std::fs::File;
 use std::io::BufReader;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use finalfusion::chunks::vocab::WordIndex;
 use finalfusion::prelude::*;
+use finalfusion::vocab::{Vocab, WordIndex};
 
 mod data;
 use data::load_corpus;


### PR DESCRIPTION
Although we disabled benchmarks in CI, the benches are still here, so I figure this need to be fixed.