### PR TITLE
Implement size_hint for ngrams and optimize unknown lookup.

### DIFF
--- a/src/compat/fasttext/indexer.rs
+++ b/src/compat/fasttext/indexer.rs
@@ -48,6 +48,10 @@ impl Indexer for FastTextIndexer {
     fn upper_bound(&self) -> u64 {
         u64::from(self.buckets)
     }
+
+    fn infallible() -> bool {
+        true
+    }
 }
 
 /// fastText FNV-1a implementation.

--- a/src/subword.rs
+++ b/src/subword.rs
@@ -21,6 +21,9 @@ pub trait Indexer {
 
     /// Return the (exclusive) upper bound of this indexer.
     fn upper_bound(&self) -> u64;
+
+    /// Indicates whether this Indexer never fails to produce an index.
+    fn infallible() -> bool;
 }
 
 /// N-Gram indexer with bucketing.
@@ -116,6 +119,10 @@ where
         // max val is <= 64
         2u64.pow(self.buckets_exp as u32)
     }
+
+    fn infallible() -> bool {
+        true
+    }
 }
 
 impl<H> PartialEq for HashIndexer<H> {
@@ -208,6 +215,10 @@ impl Indexer for ExplicitIndexer {
 
     fn upper_bound(&self) -> u64 {
         self.bound as u64
+    }
+
+    fn infallible() -> bool {
+        false
     }
 }
 
@@ -341,6 +352,12 @@ impl<'a> Iterator for NGrams<'a> {
 
         Some(ngram_with_len)
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let cap_approx = (self.max_n - self.min_n + 1) * self.char_offsets.len();
+        (cap_approx, Some(cap_approx))
+    }
 }
 
 /// Trait returning iterators over subwords and indices.
@@ -434,6 +451,11 @@ where
         self.ngrams
             .next()
             .map(|ngram| (ngram.inner, self.indexer.index_ngram(&ngram)))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.ngrams.size_hint()
     }
 }
 


### PR DESCRIPTION
For BucketIndexer, the number of ngrams (and thus subword indices)
can be precomputed. Allocating a correctly sized buffer for
the subwords yields large boosts in benches.

____________________________

This led to more than 60% improvement across unknown lookups for all storages on my machine. For some reason, known-lookup also improved by ~6% across the board.

Subword benches were down ~10%.

______________

I would've preferred to have seperate `impl<I> SubwordIndices for SubwordVocab<I> where I: BucketIndexer` and `SubwordVocab<ExplicitIndexer>` but that doesn't work because of missing specialization.

~~~Rust
let size = indices.size_hint().1.unwrap();
~~~
This is a bit of a hack since `SubwordIndices` on `str` wraps the `NGramsIndicesIter` in `FilterMap` which zeroes out the lower bound because of possible filtering. But it leaves the upper bounds untouched and we know that it's the correct size for `BucketIndexer`s since those never fail to produce.