### PR TITLE
Share strings in vocabs. 

### DIFF
--- a/src/chunks/vocab/mod.rs
+++ b/src/chunks/vocab/mod.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashMap;
 use std::io::{Read, Seek, Write};
+use std::slice;
+use std::str;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -65,13 +67,15 @@ impl WordIndex {
     }
 }
 
-pub(crate) fn create_indices(words: &[String]) -> HashMap<String, usize> {
-    let mut indices = HashMap::new();
-
+pub(crate) fn create_indices<'a, 'b>(words: &'b [String]) -> HashMap<&'a str, usize> {
+    let mut indices = HashMap::with_capacity(words.len());
     for (idx, word) in words.iter().enumerate() {
-        indices.insert(word.to_owned(), idx);
+        unsafe {
+            let bytes = slice::from_raw_parts(word.as_ptr(), word.as_bytes().len());
+            let word = str::from_utf8_unchecked(bytes);
+            indices.insert(word, idx);
+        }
     }
-
     indices
 }
 

--- a/src/chunks/vocab/simple.rs
+++ b/src/chunks/vocab/simple.rs
@@ -11,7 +11,7 @@ use crate::io::{ErrorKind, Result};
 /// Vocabulary without subword units.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SimpleVocab {
-    indices: HashMap<String, usize>,
+    indices: HashMap<&'static str, usize>,
     words: Vec<String>,
 }
 
@@ -24,6 +24,7 @@ impl SimpleVocab {
     pub fn new(words: impl Into<Vec<String>>) -> Self {
         let words = words.into();
         let indices = create_indices(&words);
+
         assert_eq!(
             words.len(),
             indices.len(),

--- a/src/chunks/vocab/subword.rs
+++ b/src/chunks/vocab/subword.rs
@@ -28,7 +28,7 @@ pub type ExplicitSubwordVocab = SubwordVocab<ExplicitIndexer>;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SubwordVocab<I> {
     indexer: I,
-    indices: HashMap<String, usize>,
+    indices: HashMap<&'static str, usize>,
     words: Vec<String>,
     min_n: u32,
     max_n: u32,

--- a/src/compat/fasttext/indexer.rs
+++ b/src/compat/fasttext/indexer.rs
@@ -48,6 +48,10 @@ impl Indexer for FastTextIndexer {
     fn upper_bound(&self) -> u64 {
         u64::from(self.buckets)
     }
+
+    fn infallible() -> bool {
+        true
+    }
 }
 
 /// fastText FNV-1a implementation.


### PR DESCRIPTION
This is not intended to be a proper PR but rather a quick idea how we could reduce the memory footprint.

Our vocabularies are immutable, so it should be save to use references to the buffers of the words in the  `Vec<String>` in the index. If I'm not missing something, this would be a cheap way to more or less half the memory requirements for our vocabularies - the same could be done for explicit ngram vocabularies, I'd expect the impact to be bigger there.

I didn't check for exact differences, I just wanted to get some feedback whether we even want to dabble in unsafe territory and whether what I wrote is sound.