### PR TITLE
Feature gate memmap dependency.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,26 @@ jobs:
           command: test
           args: --target=${{ matrix.target }}
 
+  test-no-default:
+    name: Test no-default-features
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.37.0
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ exclude = [
 byteorder = "1"
 fnv = "1"
 itertools = "0.8"
-memmap = "0.7"
 ndarray = "0.13"
 ordered-float = "1"
 rand = "0.7"
@@ -29,6 +28,13 @@ rand_xorshift = "0.2"
 reductive = "0.4"
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"
+
+[dependencies.memmap]
+version = "0.7"
+optional = true
+
+[features]
+default = ["memmap"]
 
 [dev-dependencies]
 approx = "0.3"

--- a/src/chunks/storage/mod.rs
+++ b/src/chunks/storage/mod.rs
@@ -3,10 +3,14 @@
 use ndarray::{ArrayView2, ArrayViewMut2, CowArray, Ix1};
 
 mod array;
-pub use self::array::{MmapArray, NdArray};
+#[cfg(feature = "memmap")]
+pub use self::array::MmapArray;
+pub use self::array::NdArray;
 
 mod quantized;
-pub use self::quantized::{MmapQuantizedArray, Quantize, QuantizedArray};
+#[cfg(feature = "memmap")]
+pub use self::quantized::MmapQuantizedArray;
+pub use self::quantized::{Quantize, QuantizedArray};
 
 mod wrappers;
 pub use self::wrappers::{StorageViewWrap, StorageWrap};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -39,6 +39,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "memmap")]
     fn prelude_allows_embedding_mmap_lookups() {
         let mut reader = BufReader::new(File::open("testdata/similarity.fifu").unwrap());
         let embeds_view: Embeddings<VocabWrap, StorageWrap> =
@@ -46,7 +47,7 @@ mod tests {
         assert!(embeds_view.embedding("Berlin").is_some());
     }
 
-    #[cfg(target_endian = "little")]
+    #[cfg(all(feature = "memmap", target_endian = "little"))]
     #[test]
     fn prelude_allows_embedding_mmap_view_lookups() {
         let mut reader = BufReader::new(File::open("testdata/similarity.fifu").unwrap());


### PR DESCRIPTION
Make memmap dependency optional, include as default feature.

Probably fixes #129.