### PR TITLE
Modernize and improve error handling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.37.0
+          - 1.40.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -49,7 +49,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.37.0
+          - 1.40.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.7"
 rand_xorshift = "0.2"
 reductive = "0.4"
 serde = { version = "1", features = ["derive"] }
+thiserror = "1"
 toml = "0.5"
 
 [dependencies.memmap]

--- a/src/chunks/norms.rs
+++ b/src/chunks/norms.rs
@@ -7,8 +7,8 @@ use std::ops::Deref;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use ndarray::Array1;
 
-use super::io::{ChunkIdentifier, ReadChunk, TypeId, WriteChunk};
-use crate::io::{ErrorKind, Result};
+use crate::chunks::io::{ChunkIdentifier, ReadChunk, TypeId, WriteChunk};
+use crate::error::{Error, Result};
 use crate::util::padding;
 
 /// Chunk for storing embedding l2 norms.
@@ -58,24 +58,25 @@ impl ReadChunk for NdNorms {
 
         // Read and discard chunk length.
         read.read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read norms chunk length", e))?;
+            .map_err(|e| Error::io_error("Cannot read norms chunk length", e))?;
 
         let len = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read norms vector length", e))?
+            .map_err(|e| Error::io_error("Cannot read norms vector length", e))?
             as usize;
 
         f32::ensure_data_type(read)?;
 
-        let n_padding = padding::<f32>(read.seek(SeekFrom::Current(0)).map_err(|e| {
-            ErrorKind::io_error("Cannot get file position for computing padding", e)
-        })?);
+        let n_padding =
+            padding::<f32>(read.seek(SeekFrom::Current(0)).map_err(|e| {
+                Error::io_error("Cannot get file position for computing padding", e)
+            })?);
         read.seek(SeekFrom::Current(n_padding as i64))
-            .map_err(|e| ErrorKind::io_error("Cannot skip padding", e))?;
+            .map_err(|e| Error::io_error("Cannot skip padding", e))?;
 
         let mut data = vec![0f32; len];
         read.read_f32_into::<LittleEndian>(&mut data)
-            .map_err(|e| ErrorKind::io_error("Cannot read norms", e))?;
+            .map_err(|e| Error::io_error("Cannot read norms", e))?;
 
         Ok(NdNorms::new(data))
     }
@@ -92,10 +93,11 @@ impl WriteChunk for NdNorms {
     {
         write
             .write_u32::<LittleEndian>(ChunkIdentifier::NdNorms as u32)
-            .map_err(|e| ErrorKind::io_error("Cannot write norms chunk identifier", e))?;
-        let n_padding = padding::<f32>(write.seek(SeekFrom::Current(0)).map_err(|e| {
-            ErrorKind::io_error("Cannot get file position for computing padding", e)
-        })?);
+            .map_err(|e| Error::io_error("Cannot write norms chunk identifier", e))?;
+        let n_padding =
+            padding::<f32>(write.seek(SeekFrom::Current(0)).map_err(|e| {
+                Error::io_error("Cannot get file position for computing padding", e)
+            })?);
 
         // Chunk size: len (u64), type id (u32), padding ([0,4) bytes), vector.
         let chunk_len = size_of::<u64>()
@@ -104,23 +106,23 @@ impl WriteChunk for NdNorms {
             + (self.len() * size_of::<f32>());
         write
             .write_u64::<LittleEndian>(chunk_len as u64)
-            .map_err(|e| ErrorKind::io_error("Cannot write norms chunk length", e))?;
+            .map_err(|e| Error::io_error("Cannot write norms chunk length", e))?;
         write
             .write_u64::<LittleEndian>(self.len() as u64)
-            .map_err(|e| ErrorKind::io_error("Cannot write norms vector length", e))?;
+            .map_err(|e| Error::io_error("Cannot write norms vector length", e))?;
         write
             .write_u32::<LittleEndian>(f32::type_id())
-            .map_err(|e| ErrorKind::io_error("Cannot write norms vector type identifier", e))?;
+            .map_err(|e| Error::io_error("Cannot write norms vector type identifier", e))?;
 
         let padding = vec![0; n_padding as usize];
         write
             .write_all(&padding)
-            .map_err(|e| ErrorKind::io_error("Cannot write padding", e))?;
+            .map_err(|e| Error::io_error("Cannot write padding", e))?;
 
         for &val in self.iter() {
             write
                 .write_f32::<LittleEndian>(val)
-                .map_err(|e| ErrorKind::io_error("Cannot write norm", e))?;
+                .map_err(|e| Error::io_error("Cannot write norm", e))?;
         }
 
         Ok(())

--- a/src/chunks/storage/array.rs
+++ b/src/chunks/storage/array.rs
@@ -18,7 +18,7 @@ use super::{Storage, StorageView, StorageViewMut};
 #[cfg(feature = "memmap")]
 use crate::chunks::io::MmapChunk;
 use crate::chunks::io::{ChunkIdentifier, ReadChunk, TypeId, WriteChunk};
-use crate::io::{Error, ErrorKind, Result};
+use crate::error::{Error, Result};
 use crate::util::padding;
 
 /// Memory-mapped matrix.
@@ -80,29 +80,31 @@ impl MmapChunk for MmapArray {
 
         // Read and discard chunk length.
         read.read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read embedding matrix chunk length", e))?;
+            .map_err(|e| Error::io_error("Cannot read embedding matrix chunk length", e))?;
 
-        let rows = read.read_u64::<LittleEndian>().map_err(|e| {
-            ErrorKind::io_error("Cannot read number of rows of the embedding matrix", e)
-        })? as usize;
+        let rows = read
+            .read_u64::<LittleEndian>()
+            .map_err(|e| Error::io_error("Cannot read number of rows of the embedding matrix", e))?
+            as usize;
         let cols = read.read_u32::<LittleEndian>().map_err(|e| {
-            ErrorKind::io_error("Cannot read number of columns of the embedding matrix", e)
+            Error::io_error("Cannot read number of columns of the embedding matrix", e)
         })? as usize;
         let shape = Ix2(rows, cols);
 
         // The components of the embedding matrix should be of type f32.
         f32::ensure_data_type(read)?;
 
-        let n_padding = padding::<f32>(read.seek(SeekFrom::Current(0)).map_err(|e| {
-            ErrorKind::io_error("Cannot get file position for computing padding", e)
-        })?);
+        let n_padding =
+            padding::<f32>(read.seek(SeekFrom::Current(0)).map_err(|e| {
+                Error::io_error("Cannot get file position for computing padding", e)
+            })?);
         read.seek(SeekFrom::Current(n_padding as i64))
-            .map_err(|e| ErrorKind::io_error("Cannot skip padding", e))?;
+            .map_err(|e| Error::io_error("Cannot skip padding", e))?;
 
         // Set up memory mapping.
         let matrix_len = shape.size() * size_of::<f32>();
         let offset = read.seek(SeekFrom::Current(0)).map_err(|e| {
-            ErrorKind::io_error(
+            Error::io_error(
                 "Cannot get file position for memory mapping embedding matrix",
                 e,
             )
@@ -113,12 +115,12 @@ impl MmapChunk for MmapArray {
                 .offset(offset)
                 .len(matrix_len)
                 .map(&read.get_ref())
-                .map_err(|e| ErrorKind::io_error("Cannot memory map embedding matrix", e))?
+                .map_err(|e| Error::io_error("Cannot memory map embedding matrix", e))?
         };
 
         // Position the reader after the matrix.
         read.seek(SeekFrom::Current(matrix_len as i64))
-            .map_err(|e| ErrorKind::io_error("Cannot skip embedding matrix", e))?;
+            .map_err(|e| Error::io_error("Cannot skip embedding matrix", e))?;
 
         Ok(MmapArray { map, shape })
     }
@@ -155,12 +157,11 @@ impl NdArray {
     {
         write
             .write_u32::<LittleEndian>(ChunkIdentifier::NdArray as u32)
-            .map_err(|e| {
-                ErrorKind::io_error("Cannot write embedding matrix chunk identifier", e)
-            })?;
-        let n_padding = padding::<f32>(write.seek(SeekFrom::Current(0)).map_err(|e| {
-            ErrorKind::io_error("Cannot get file position for computing padding", e)
-        })?);
+            .map_err(|e| Error::io_error("Cannot write embedding matrix chunk identifier", e))?;
+        let n_padding =
+            padding::<f32>(write.seek(SeekFrom::Current(0)).map_err(|e| {
+                Error::io_error("Cannot get file position for computing padding", e)
+            })?);
         // Chunk size: rows (u64), columns (u32), type id (u32),
         //             padding ([0,4) bytes), matrix.
         let chunk_len = size_of::<u64>()
@@ -170,20 +171,20 @@ impl NdArray {
             + (data.nrows() * data.ncols() * size_of::<f32>());
         write
             .write_u64::<LittleEndian>(chunk_len as u64)
-            .map_err(|e| ErrorKind::io_error("Cannot write embedding matrix chunk length", e))?;
+            .map_err(|e| Error::io_error("Cannot write embedding matrix chunk length", e))?;
         write
             .write_u64::<LittleEndian>(data.nrows() as u64)
             .map_err(|e| {
-                ErrorKind::io_error("Cannot write number of rows of the embedding matrix", e)
+                Error::io_error("Cannot write number of rows of the embedding matrix", e)
             })?;
         write
             .write_u32::<LittleEndian>(data.ncols() as u32)
             .map_err(|e| {
-                ErrorKind::io_error("Cannot write number of columns of the embedding matrix", e)
+                Error::io_error("Cannot write number of columns of the embedding matrix", e)
             })?;
         write
             .write_u32::<LittleEndian>(f32::type_id())
-            .map_err(|e| ErrorKind::io_error("Cannot write embedding matrix type identifier", e))?;
+            .map_err(|e| Error::io_error("Cannot write embedding matrix type identifier", e))?;
 
         // Write padding, such that the embedding matrix starts on at
         // a multiple of the size of f32 (4 bytes). This is necessary
@@ -199,13 +200,13 @@ impl NdArray {
         let padding = vec![0; n_padding as usize];
         write
             .write_all(&padding)
-            .map_err(|e| ErrorKind::io_error("Cannot write padding", e))?;
+            .map_err(|e| Error::io_error("Cannot write padding", e))?;
 
         for row in data.outer_iter() {
             for col in row.iter() {
-                write.write_f32::<LittleEndian>(*col).map_err(|e| {
-                    ErrorKind::io_error("Cannot write embedding matrix component", e)
-                })?;
+                write
+                    .write_f32::<LittleEndian>(*col)
+                    .map_err(|e| Error::io_error("Cannot write embedding matrix component", e))?;
             }
         }
 
@@ -244,27 +245,29 @@ impl ReadChunk for NdArray {
 
         // Read and discard chunk length.
         read.read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read embedding matrix chunk length", e))?;
+            .map_err(|e| Error::io_error("Cannot read embedding matrix chunk length", e))?;
 
-        let rows = read.read_u64::<LittleEndian>().map_err(|e| {
-            ErrorKind::io_error("Cannot read number of rows of the embedding matrix", e)
-        })? as usize;
+        let rows = read
+            .read_u64::<LittleEndian>()
+            .map_err(|e| Error::io_error("Cannot read number of rows of the embedding matrix", e))?
+            as usize;
         let cols = read.read_u32::<LittleEndian>().map_err(|e| {
-            ErrorKind::io_error("Cannot read number of columns of the embedding matrix", e)
+            Error::io_error("Cannot read number of columns of the embedding matrix", e)
         })? as usize;
 
         // The components of the embedding matrix should be of type f32.
         f32::ensure_data_type(read)?;
 
-        let n_padding = padding::<f32>(read.seek(SeekFrom::Current(0)).map_err(|e| {
-            ErrorKind::io_error("Cannot get file position for computing padding", e)
-        })?);
+        let n_padding =
+            padding::<f32>(read.seek(SeekFrom::Current(0)).map_err(|e| {
+                Error::io_error("Cannot get file position for computing padding", e)
+            })?);
         read.seek(SeekFrom::Current(n_padding as i64))
-            .map_err(|e| ErrorKind::io_error("Cannot skip padding", e))?;
+            .map_err(|e| Error::io_error("Cannot skip padding", e))?;
 
         let mut data = vec![0f32; rows * cols];
         read.read_f32_into::<LittleEndian>(&mut data)
-            .map_err(|e| ErrorKind::io_error("Cannot read embedding matrix", e))?;
+            .map_err(|e| Error::io_error("Cannot read embedding matrix", e))?;
 
         Ok(NdArray {
             inner: Array2::from_shape_vec((rows, cols), data).map_err(Error::Shape)?,

--- a/src/chunks/vocab/mod.rs
+++ b/src/chunks/vocab/mod.rs
@@ -5,7 +5,7 @@ use std::io::{Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
-use crate::io::{Error, ErrorKind, Result};
+use crate::error::{Error, Result};
 
 mod subword;
 pub use subword::{
@@ -81,15 +81,14 @@ where
 {
     let mut items = Vec::with_capacity(len);
     for _ in 0..len {
-        let item_len = read
-            .read_u32::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read item length", e))?
-            as usize;
+        let item_len =
+            read.read_u32::<LittleEndian>()
+                .map_err(|e| Error::io_error("Cannot read item length", e))? as usize;
         let mut bytes = vec![0; item_len];
         read.read_exact(&mut bytes)
-            .map_err(|e| ErrorKind::io_error("Cannot read item", e))?;
+            .map_err(|e| Error::io_error("Cannot read item", e))?;
         let item = String::from_utf8(bytes)
-            .map_err(|e| ErrorKind::Format(format!("Item contains invalid UTF-8: {}", e)))
+            .map_err(|e| Error::Format(format!("Item contains invalid UTF-8: {}", e)))
             .map_err(Error::from)?;
         items.push(item);
     }
@@ -103,10 +102,10 @@ where
     for word in items {
         write
             .write_u32::<LittleEndian>(word.len() as u32)
-            .map_err(|e| ErrorKind::io_error("Cannot write token length", e))?;
+            .map_err(|e| Error::io_error("Cannot write token length", e))?;
         write
             .write_all(word.as_bytes())
-            .map_err(|e| ErrorKind::io_error("Cannot write token", e))?;
+            .map_err(|e| Error::io_error("Cannot write token", e))?;
     }
     Ok(())
 }

--- a/src/chunks/vocab/simple.rs
+++ b/src/chunks/vocab/simple.rs
@@ -6,7 +6,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::chunks::io::{ChunkIdentifier, ReadChunk, WriteChunk};
 use crate::chunks::vocab::{create_indices, read_vocab_items, write_vocab_items, Vocab, WordIndex};
-use crate::io::{ErrorKind, Result};
+use crate::error::{Error, Result};
 
 /// Vocabulary without subword units.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -60,11 +60,11 @@ impl ReadChunk for SimpleVocab {
 
         // Read and discard chunk length.
         read.read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read vocabulary chunk length", e))?;
+            .map_err(|e| Error::io_error("Cannot read vocabulary chunk length", e))?;
 
         let vocab_len = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read vocabulary length", e))?
+            .map_err(|e| Error::io_error("Cannot read vocabulary length", e))?
             as usize;
 
         let words = read_vocab_items(read, vocab_len)?;
@@ -93,13 +93,13 @@ impl WriteChunk for SimpleVocab {
 
         write
             .write_u32::<LittleEndian>(ChunkIdentifier::SimpleVocab as u32)
-            .map_err(|e| ErrorKind::io_error("Cannot write vocabulary chunk identifier", e))?;
+            .map_err(|e| Error::io_error("Cannot write vocabulary chunk identifier", e))?;
         write
             .write_u64::<LittleEndian>(chunk_len as u64)
-            .map_err(|e| ErrorKind::io_error("Cannot write vocabulary chunk length", e))?;
+            .map_err(|e| Error::io_error("Cannot write vocabulary chunk length", e))?;
         write
             .write_u64::<LittleEndian>(self.words.len() as u64)
-            .map_err(|e| ErrorKind::io_error("Cannot write vocabulary length", e))?;
+            .map_err(|e| Error::io_error("Cannot write vocabulary length", e))?;
 
         write_vocab_items(write, self.words())?;
 

--- a/src/chunks/vocab/subword.rs
+++ b/src/chunks/vocab/subword.rs
@@ -8,7 +8,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use crate::chunks::io::{ChunkIdentifier, ReadChunk, WriteChunk};
 use crate::chunks::vocab::{create_indices, read_vocab_items, write_vocab_items, Vocab, WordIndex};
 use crate::compat::fasttext::FastTextIndexer;
-use crate::io::{Error, ErrorKind, Result};
+use crate::error::{Error, Result};
 use crate::subword::{
     BucketIndexer, ExplicitIndexer, FinalfusionHashIndexer, Indexer,
     SubwordIndices as StrSubwordIndices,
@@ -264,21 +264,21 @@ where
 
         // Read and discard chunk length.
         read.read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read vocabulary chunk length", e))?;
+            .map_err(|e| Error::io_error("Cannot read vocabulary chunk length", e))?;
 
         let vocab_len = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read vocabulary length", e))?
+            .map_err(|e| Error::io_error("Cannot read vocabulary length", e))?
             as usize;
         let min_n = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read minimum n-gram length", e))?;
+            .map_err(|e| Error::io_error("Cannot read minimum n-gram length", e))?;
         let max_n = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read maximum n-gram length", e))?;
+            .map_err(|e| Error::io_error("Cannot read maximum n-gram length", e))?;
         let buckets = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read number of buckets", e))?;
+            .map_err(|e| Error::io_error("Cannot read number of buckets", e))?;
 
         let words = read_vocab_items(read, vocab_len as usize)?;
 
@@ -314,24 +314,22 @@ where
 
         write
             .write_u32::<LittleEndian>(chunk_identifier as u32)
-            .map_err(|e| {
-                ErrorKind::io_error("Cannot write subword vocabulary chunk identifier", e)
-            })?;
+            .map_err(|e| Error::io_error("Cannot write subword vocabulary chunk identifier", e))?;
         write
             .write_u64::<LittleEndian>(chunk_len as u64)
-            .map_err(|e| ErrorKind::io_error("Cannot write subword vocabulary chunk length", e))?;
+            .map_err(|e| Error::io_error("Cannot write subword vocabulary chunk length", e))?;
         write
             .write_u64::<LittleEndian>(self.words.len() as u64)
-            .map_err(|e| ErrorKind::io_error("Cannot write vocabulary length", e))?;
+            .map_err(|e| Error::io_error("Cannot write vocabulary length", e))?;
         write
             .write_u32::<LittleEndian>(self.min_n)
-            .map_err(|e| ErrorKind::io_error("Cannot write minimum n-gram length", e))?;
+            .map_err(|e| Error::io_error("Cannot write minimum n-gram length", e))?;
         write
             .write_u32::<LittleEndian>(self.max_n)
-            .map_err(|e| ErrorKind::io_error("Cannot write maximum n-gram length", e))?;
+            .map_err(|e| Error::io_error("Cannot write maximum n-gram length", e))?;
         write
             .write_u32::<LittleEndian>(self.indexer.buckets() as u32)
-            .map_err(|e| ErrorKind::io_error("Cannot write number of buckets", e))?;
+            .map_err(|e| Error::io_error("Cannot write number of buckets", e))?;
 
         write_vocab_items(write, self.words())?;
 
@@ -350,19 +348,19 @@ impl SubwordVocab<ExplicitIndexer> {
         ChunkIdentifier::ensure_chunk_type(read, chunk_identifier)?;
         // Read and discard chunk length.
         read.read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read vocabulary chunk length", e))?;
+            .map_err(|e| Error::io_error("Cannot read vocabulary chunk length", e))?;
         let words_len = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read number of words", e))?;
+            .map_err(|e| Error::io_error("Cannot read number of words", e))?;
         let ngrams_len = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read number of ngrams", e))?;
+            .map_err(|e| Error::io_error("Cannot read number of ngrams", e))?;
         let min_n = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read minimum n-gram length", e))?;
+            .map_err(|e| Error::io_error("Cannot read minimum n-gram length", e))?;
         let max_n = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read maximum n-gram length", e))?;
+            .map_err(|e| Error::io_error("Cannot read maximum n-gram length", e))?;
 
         let words = read_vocab_items(read, words_len as usize)?;
         let ngrams = read_ngrams_with_indices(read, ngrams_len as usize)?;
@@ -397,24 +395,22 @@ impl SubwordVocab<ExplicitIndexer> {
 
         write
             .write_u32::<LittleEndian>(chunk_identifier as u32)
-            .map_err(|e| {
-                ErrorKind::io_error("Cannot write subword vocabulary chunk identifier", e)
-            })?;
+            .map_err(|e| Error::io_error("Cannot write subword vocabulary chunk identifier", e))?;
         write
             .write_u64::<LittleEndian>(chunk_len as u64)
-            .map_err(|e| ErrorKind::io_error("Cannot write subword vocabulary chunk length", e))?;
+            .map_err(|e| Error::io_error("Cannot write subword vocabulary chunk length", e))?;
         write
             .write_u64::<LittleEndian>(self.words.len() as u64)
-            .map_err(|e| ErrorKind::io_error("Cannot write vocabulary length", e))?;
+            .map_err(|e| Error::io_error("Cannot write vocabulary length", e))?;
         write
             .write_u64::<LittleEndian>(self.indexer.ngrams().len() as u64)
-            .map_err(|e| ErrorKind::io_error("Cannot write ngram length", e))?;
+            .map_err(|e| Error::io_error("Cannot write ngram length", e))?;
         write
             .write_u32::<LittleEndian>(self.min_n)
-            .map_err(|e| ErrorKind::io_error("Cannot write minimum n-gram length", e))?;
+            .map_err(|e| Error::io_error("Cannot write minimum n-gram length", e))?;
         write
             .write_u32::<LittleEndian>(self.max_n)
-            .map_err(|e| ErrorKind::io_error("Cannot write maximum n-gram length", e))?;
+            .map_err(|e| Error::io_error("Cannot write maximum n-gram length", e))?;
 
         write_vocab_items(write, self.words())?;
         write_ngrams_with_indices(write, self.indexer())?;
@@ -429,19 +425,18 @@ where
 {
     let mut ngrams = Vec::with_capacity(len);
     for _ in 0..len {
-        let ngram_len = read
-            .read_u32::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read item length", e))?
-            as usize;
+        let ngram_len =
+            read.read_u32::<LittleEndian>()
+                .map_err(|e| Error::io_error("Cannot read item length", e))? as usize;
         let mut bytes = vec![0; ngram_len];
         read.read_exact(&mut bytes)
-            .map_err(|e| ErrorKind::io_error("Cannot read item", e))?;
+            .map_err(|e| Error::io_error("Cannot read item", e))?;
         let item = String::from_utf8(bytes)
-            .map_err(|e| ErrorKind::Format(format!("Item contains invalid UTF-8: {}", e)))
+            .map_err(|e| Error::Format(format!("Item contains invalid UTF-8: {}", e)))
             .map_err(Error::from)?;
         let idx = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| ErrorKind::io_error("Cannot read ngram index.", e))?;
+            .map_err(|e| Error::io_error("Cannot read ngram index.", e))?;
         ngrams.push((item, idx));
     }
     Ok(ngrams)
@@ -453,7 +448,7 @@ where
 {
     for ngram in indexer.ngrams() {
         let idx = indexer.index_ngram(&ngram.as_str().into()).ok_or_else(|| {
-            ErrorKind::io_error(
+            Error::io_error(
                 format!(
                     "Indexer could not index n-gram during serialization: {}",
                     ngram
@@ -463,13 +458,13 @@ where
         })?;
         write
             .write_u32::<LittleEndian>(ngram.len() as u32)
-            .map_err(|e| ErrorKind::io_error("Cannot write ngram length", e))?;
+            .map_err(|e| Error::io_error("Cannot write ngram length", e))?;
         write
             .write_all(ngram.as_bytes())
-            .map_err(|e| ErrorKind::io_error("Cannot write ngram", e))?;
+            .map_err(|e| Error::io_error("Cannot write ngram", e))?;
         write
             .write_u64::<LittleEndian>(idx)
-            .map_err(|e| ErrorKind::io_error("Cannot write ngram idx", e))?;
+            .map_err(|e| Error::io_error("Cannot write ngram idx", e))?;
     }
     Ok(())
 }

--- a/src/compat/word2vec.rs
+++ b/src/compat/word2vec.rs
@@ -28,7 +28,7 @@ use crate::chunks::norms::NdNorms;
 use crate::chunks::storage::{NdArray, Storage, StorageViewMut};
 use crate::chunks::vocab::{SimpleVocab, Vocab};
 use crate::embeddings::Embeddings;
-use crate::io::{ErrorKind, Result};
+use crate::error::{Error, Result};
 use crate::util::{l2_normalize_array, read_number, read_string};
 
 /// Method to construct `Embeddings` from a word2vec binary file.
@@ -104,7 +104,7 @@ where
                 .read_f32_into::<LittleEndian>(
                     embedding.as_slice_mut().expect("Matrix not contiguous"),
                 )
-                .map_err(|e| ErrorKind::io_error("Cannot read word embedding", e))?;
+                .map_err(|e| Error::io_error("Cannot read word embedding", e))?;
         }
 
         Ok(Embeddings::new_without_norms(
@@ -141,10 +141,10 @@ where
         W: Write,
     {
         writeln!(w, "{} {}", self.vocab().words_len(), self.dims())
-            .map_err(|e| ErrorKind::io_error("Cannot write word embedding matrix shape", e))?;
+            .map_err(|e| Error::io_error("Cannot write word embedding matrix shape", e))?;
 
         for (word, embed_norm) in self.iter_with_norms() {
-            write!(w, "{} ", word).map_err(|e| ErrorKind::io_error("Cannot write token", e))?;
+            write!(w, "{} ", word).map_err(|e| Error::io_error("Cannot write token", e))?;
 
             let embed = if unnormalize {
                 CowArray::from(embed_norm.into_unnormalized())
@@ -154,11 +154,11 @@ where
 
             for v in embed.view() {
                 w.write_f32::<LittleEndian>(*v)
-                    .map_err(|e| ErrorKind::io_error("Cannot write embedding component", e))?;
+                    .map_err(|e| Error::io_error("Cannot write embedding component", e))?;
             }
 
             w.write_all(&[0x0a])
-                .map_err(|e| ErrorKind::io_error("Cannot write embedding separator", e))?;
+                .map_err(|e| Error::io_error("Cannot write embedding separator", e))?;
         }
 
         Ok(())

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -29,9 +29,10 @@ use crate::chunks::vocab::{
     BucketSubwordVocab, ExplicitSubwordVocab, FastTextSubwordVocab, SimpleVocab, Vocab, VocabWrap,
     WordIndex,
 };
+use crate::error::{Error, Result};
 #[cfg(feature = "memmap")]
 use crate::io::MmapEmbeddings;
-use crate::io::{ErrorKind, ReadEmbeddings, Result, WriteEmbeddings};
+use crate::io::{ReadEmbeddings, WriteEmbeddings};
 use crate::util::l2_normalize;
 
 /// Word embeddings.
@@ -350,9 +351,9 @@ where
         let header = Header::read_chunk(read)?;
         let chunks = header.chunk_identifiers();
         if chunks.is_empty() {
-            return Err(
-                ErrorKind::Format(String::from("Embedding file does not contain chunks")).into(),
-            );
+            return Err(Error::Format(String::from(
+                "Embedding file does not contain chunks",
+            )));
         }
 
         let metadata = if header.chunk_identifiers()[0] == ChunkIdentifier::Metadata {
@@ -386,9 +387,9 @@ where
         let header = Header::read_chunk(read)?;
         let chunks = header.chunk_identifiers();
         if chunks.is_empty() {
-            return Err(
-                ErrorKind::Format(String::from("Embedding file does not contain chunks")).into(),
-            );
+            return Err(Error::Format(String::from(
+                "Embedding file does not contain chunks",
+            )));
         }
 
         let metadata = if header.chunk_identifiers()[0] == ChunkIdentifier::Metadata {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,37 @@
+//! Error/result types
+
+use std::io;
+
+use ndarray::ShapeError;
+use thiserror::Error;
+
+/// `Result` type alias for operations that can lead to I/O errors.
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+/// finalfusion errors
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Invalid file format.
+    #[error("Invalid file format {0}")]
+    Format(String),
+
+    /// `ndarray` shape error.
+    #[error(transparent)]
+    Shape(#[from] ShapeError),
+
+    #[error("{desc:?}: {error:?}")]
+    Io { desc: String, error: io::Error },
+
+    #[error("Unknown chunk identifier {0}")]
+    UnknownChunkIdentifier(u32),
+}
+
+impl Error {
+    pub fn io_error(desc: impl Into<String>, error: io::Error) -> Self {
+        Error::Io {
+            desc: desc.into(),
+            error,
+        }
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -6,84 +6,10 @@
 //! provides the `Error`, `ErrorKind`, and `Result` types that are
 //! used for handling I/O errors throughout the crate.
 
-use std::fmt;
 use std::fs::File;
-use std::io;
 use std::io::{BufReader, Read, Seek, Write};
 
-use ndarray::ShapeError;
-
-/// `Result` type alias for operations that can lead to I/O errors.
-pub type Result<T> = ::std::result::Result<T, Error>;
-
-/// I/O errors in reading or writing embeddings.
-#[derive(Debug)]
-pub enum Error {
-    /// finalfusion errors.
-    FinalFusion(ErrorKind),
-
-    /// `ndarray` shape error.
-    Shape(ShapeError),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-        match *self {
-            FinalFusion(ref kind) => kind.fmt(f),
-            Shape(ref err) => err.fmt(f),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        use self::Error::*;
-
-        match *self {
-            FinalFusion(ErrorKind::Format(ref desc)) => desc,
-            FinalFusion(ErrorKind::Io { ref desc, .. }) => desc,
-            Shape(ref err) => err.description(),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum ErrorKind {
-    /// Invalid file format.
-    Format(String),
-
-    /// I/O error.
-    Io { desc: String, error: io::Error },
-}
-
-impl ErrorKind {
-    pub fn io_error(desc: impl Into<String>, error: io::Error) -> Self {
-        ErrorKind::Io {
-            desc: desc.into(),
-            error,
-        }
-    }
-}
-
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::ErrorKind::*;
-        match *self {
-            Format(ref desc) => write!(f, "{}", desc),
-            Io {
-                ref desc,
-                ref error,
-            } => write!(f, "{}: {}", desc, error),
-        }
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Error {
-        Error::FinalFusion(kind)
-    }
-}
+use crate::error::Result;
 
 /// Read finalfusion embeddings.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@ pub mod compat;
 
 pub mod embeddings;
 
+pub mod error;
+
 pub mod io;
 
 pub mod prelude;

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::io::BufRead;
 use std::mem::size_of;
 
-use crate::io::{Error, ErrorKind, Result};
+use crate::error::{Error, Result};
 use ndarray::{Array1, ArrayViewMut1, ArrayViewMut2};
 
 /// Conversion from an `Iterator` into a collection with a given
@@ -90,7 +90,7 @@ pub fn read_number(reader: &mut dyn BufRead, delim: u8) -> Result<usize> {
     field_str
         .parse()
         .map_err(|e| {
-            ErrorKind::Format(format!(
+            Error::Format(format!(
                 "Cannot parse shape component '{}': {}",
                 field_str, e
             ))
@@ -102,14 +102,14 @@ pub fn read_string(reader: &mut dyn BufRead, delim: u8, lossy: bool) -> Result<S
     let mut buf = Vec::new();
     reader
         .read_until(delim, &mut buf)
-        .map_err(|e| ErrorKind::io_error("Cannot read string", e))?;
+        .map_err(|e| Error::io_error("Cannot read string", e))?;
     buf.pop();
 
     let s = if lossy {
         String::from_utf8_lossy(&buf).into_owned()
     } else {
         String::from_utf8(buf)
-            .map_err(|e| ErrorKind::Format(format!("Token contains invalid UTF-8: {}", e)))?
+            .map_err(|e| Error::Format(format!("Token contains invalid UTF-8: {}", e)))?
     };
 
     Ok(s)


### PR DESCRIPTION
- Merge the `Error` and `ErrorKind` enums.
- Move the `Error` enum to the `error` module.
- Derive trait implementations using the `thiserror` crate.
- Make the `Error` enum non-exhaustive
- Replace the `ChunkIdentifier::try_from` method by an implementation
  of the `TryFrom` crate.