### PR TITLE
Add the Reconstruct trait as a counterpart to Quantize

### DIFF
--- a/src/chunks/storage/array.rs
+++ b/src/chunks/storage/array.rs
@@ -228,6 +228,12 @@ impl From<Array2<f32>> for NdArray {
     }
 }
 
+impl From<NdArray> for Array2<f32> {
+    fn from(arr: NdArray) -> Self {
+        arr.inner
+    }
+}
+
 impl Storage for NdArray {
     fn embedding(&self, idx: usize) -> CowArray<f32, Ix1> {
         CowArray::from(self.inner.row(idx))

--- a/src/chunks/storage/mod.rs
+++ b/src/chunks/storage/mod.rs
@@ -10,7 +10,7 @@ pub use self::array::NdArray;
 mod quantized;
 #[cfg(feature = "memmap")]
 pub use self::quantized::MmapQuantizedArray;
-pub use self::quantized::{Quantize, QuantizedArray};
+pub use self::quantized::{Quantize, QuantizedArray, Reconstruct};
 
 mod wrappers;
 pub use self::wrappers::{StorageViewWrap, StorageWrap};


### PR DESCRIPTION
This trait can be used to reconstruct quantized embeddings.