### PR TITLE
SubwordVocab: check that lengths can be represented by usize

### DIFF
--- a/src/chunks/vocab/subword.rs
+++ b/src/chunks/vocab/subword.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::io;
 use std::io::{Read, Seek, Write};
 use std::mem::size_of;
@@ -55,6 +56,21 @@ where
             words.len(),
             indices.len(),
             "words contained duplicate entries."
+        );
+
+        // Check that usize can represent the indexer's upper bound.
+        assert!(
+            usize::try_from(indexer.upper_bound()).is_ok(),
+            "The upper bound of the indexer cannot be represented by the native word size."
+        );
+
+        // Check that usize can represent the combined vocabulary sizes.
+        assert!(
+            words
+                .len()
+                .checked_add(indexer.upper_bound() as usize)
+                .is_some(),
+            "The vocab + subword vocab size cannot be represented by the native word size"
         );
 
         SubwordVocab {


### PR DESCRIPTION
finalfusion was developed with the assumption that it would run on
64-bit platforms and thus that embedding index computations would
never overflow. However, this can happen on x86, especially in subword
vocabs. Make this less likely to happen by enforcing two envariants:

- The upper bound of an indexer should by representable by usize.
- The size of the word vocabulary plus the upper bound of the indexer
  should be representable as usize.