### PR TITLE
Perform checked u64 -> usize casts in chunk I/O

### DIFF
--- a/src/chunks/norms.rs
+++ b/src/chunks/norms.rs
@@ -1,5 +1,6 @@
 //! Norms chunk
 
+use std::convert::TryInto;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
 use std::ops::Deref;
@@ -63,7 +64,8 @@ impl ReadChunk for NdNorms {
         let len = read
             .read_u64::<LittleEndian>()
             .map_err(|e| Error::io_error("Cannot read norms vector length", e))?
-            as usize;
+            .try_into()
+            .map_err(|_| Error::Overflow)?;
 
         f32::ensure_data_type(read)?;
 

--- a/src/chunks/storage/quantized.rs
+++ b/src/chunks/storage/quantized.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
 
@@ -67,7 +68,8 @@ impl QuantizedArray {
         let n_embeddings = read
             .read_u64::<LittleEndian>()
             .map_err(|e| Error::io_error("Cannot read number of quantized embeddings", e))?
-            as usize;
+            .try_into()
+            .map_err(|_| Error::Overflow)?;
 
         Self::check_quantizer_invariants(quantized_len, reconstructed_len)?;
 

--- a/src/chunks/vocab/simple.rs
+++ b/src/chunks/vocab/simple.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::io::{Read, Seek, Write};
 use std::mem::size_of;
 
@@ -65,7 +66,8 @@ impl ReadChunk for SimpleVocab {
         let vocab_len = read
             .read_u64::<LittleEndian>()
             .map_err(|e| Error::io_error("Cannot read vocabulary length", e))?
-            as usize;
+            .try_into()
+            .map_err(|_| Error::Overflow)?;
 
         let words = read_vocab_items(read, vocab_len)?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,9 @@ pub enum Error {
 
     #[error("Unknown chunk identifier {0}")]
     UnknownChunkIdentifier(u32),
+
+    #[error("Data cannot be represented using native word size")]
+    Overflow,
 }
 
 impl Error {


### PR DESCRIPTION
Casting padding is excepted, since padding is bound by the size of the
types we perform padding for.