### PR TITLE
Storage: allow lookup of multiple embeddings at the same time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,10 @@ default = ["memmap"]
 
 [dev-dependencies]
 approx = "0.3"
-maplit = "1"
-lazy_static = "1"
 criterion = "0.3"
+lazy_static = "1"
+maplit = "1"
+tempfile = "3"
 
 [[bench]]
 name = "array"

--- a/src/chunks/storage/mod.rs
+++ b/src/chunks/storage/mod.rs
@@ -1,6 +1,6 @@
 //! Embedding matrix representations.
 
-use ndarray::{ArrayView2, ArrayViewMut2, CowArray, Ix1};
+use ndarray::{Array2, ArrayView2, ArrayViewMut2, CowArray, Ix1};
 
 mod array;
 #[cfg(feature = "memmap")]
@@ -22,6 +22,9 @@ pub use self::wrappers::{StorageViewWrap, StorageWrap};
 /// abstracts over concrete storage types.
 pub trait Storage {
     fn embedding(&self, idx: usize) -> CowArray<f32, Ix1>;
+
+    /// Retrieve multiple embeddings.
+    fn embeddings(&self, indices: &[usize]) -> Array2<f32>;
 
     fn shape(&self) -> (usize, usize);
 }


### PR DESCRIPTION
There is some noise around the tests for the quantized embeddings. The amount of feature gating was getting a bit out of hand, so I moved all the tests that use memory-mapped quantized storage to a submodule.