### PR TITLE
Embeddings::embedding: use Storage::embeddings

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -5,7 +5,7 @@ use std::iter::Enumerate;
 use std::mem;
 use std::slice;
 
-use ndarray::{Array1, ArrayViewMut1, CowArray, Ix1};
+use ndarray::{Array1, ArrayViewMut1, Axis, CowArray, Ix1};
 use rand::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use reductive::pq::TrainPQ;
@@ -135,11 +135,8 @@ where
         match self.vocab.idx(word)? {
             WordIndex::Word(idx) => Some(self.storage.embedding(idx)),
             WordIndex::Subword(indices) => {
-                let mut embed = Array1::zeros((self.storage.shape().1,));
-                for idx in indices {
-                    embed += &self.storage.embedding(idx).view();
-                }
-
+                let embeds = self.storage.embeddings(&indices);
+                let mut embed = embeds.sum_axis(Axis(0));
                 l2_normalize(embed.view_mut());
 
                 Some(CowArray::from(embed))


### PR DESCRIPTION
This makes lookups of unknown words faster, especially for quantized
embeddings.

Benchmarking results with differences larger than 5%:

![Screenshot from 2020-06-04 12-04-55](https://user-images.githubusercontent.com/49398/83743880-a2b18880-a65b-11ea-9407-2cb6f3222bca.png)

* Lookups for `NdArray` became ~7-14% slower. Probably because of the extra allocation of the matrix by `Embeddings::storage`.
* Lookups for `MmapArray` became ~15-16% faster. Maybe the combined mmap -> `ArrayView` + select allows better optimization?
* As expected, lookups for `QuantizedArray` are much faster, ~164% for unknowns and ~60% allround.

I think it's worth it. Array lookups are extremely fast already, so the loss is barely noticable, whereas this will give a nice speedup for opq embeddings.

I guess there is another micro-optimization where we could use a regular lookup when the array of indices only has one element. But I guess that's too rare to be interesting.