### PR TITLE
Implement conversion to explicit subword embeddings.

### DIFF
--- a/src/chunks/storage/mod.rs
+++ b/src/chunks/storage/mod.rs
@@ -29,6 +29,20 @@ pub trait Storage {
     fn shape(&self) -> (usize, usize);
 }
 
+pub(crate) mod sealed {
+    use crate::chunks::storage::Storage;
+
+    /// Return a new storage from an existing Storage based on a mapping.
+    pub trait CloneFromMapping {
+        type Result: Storage;
+
+        /// Construct a new Storage based on a mapping.
+        ///
+        /// The `i`th entry in the returned storage is based on `self.embedding(mapping[i])`.
+        fn clone_from_mapping(&self, mapping: &[usize]) -> Self::Result;
+    }
+}
+
 /// Storage that provide a view of the embedding matrix.
 pub trait StorageView: Storage {
     /// Get a view of the embedding matrix.

--- a/src/compat/text.rs
+++ b/src/compat/text.rs
@@ -265,10 +265,11 @@ where
 
     let matrix = Array2::from_shape_vec(shape, data).map_err(Error::Shape)?;
 
-    Ok(Embeddings::new_without_norms(
+    Ok(Embeddings::new_with_maybe_norms(
         None,
         SimpleVocab::new(words),
         NdArray::new(matrix),
+        None,
     ))
 }
 

--- a/src/compat/word2vec.rs
+++ b/src/compat/word2vec.rs
@@ -107,10 +107,11 @@ where
                 .map_err(|e| Error::io_error("Cannot read word embedding", e))?;
         }
 
-        Ok(Embeddings::new_without_norms(
+        Ok(Embeddings::new_with_maybe_norms(
             None,
             SimpleVocab::new(words),
             NdArray::new(matrix),
+            None,
         ))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
 
     #[error("Data cannot be represented using native word size")]
     Overflow,
+
+    #[error("Can't convert {from:?} to {to:?}")]
+    ConversionError { from: String, to: String },
 }
 
 impl Error {
@@ -35,6 +38,13 @@ impl Error {
         Error::Io {
             desc: desc.into(),
             error,
+        }
+    }
+
+    pub fn conversion_error(from: impl Into<String>, to: impl Into<String>) -> Self {
+        Error::ConversionError {
+            from: from.into(),
+            to: to.into(),
         }
     }
 }

--- a/src/subword.rs
+++ b/src/subword.rs
@@ -185,8 +185,13 @@ impl ExplicitIndexer {
     /// `(0..n_original_indices)` where `n_original_indices` is the number of unique indices in the
     /// `subword -> index` mapping.
     ///
+    /// The second item in the returned tuple holds the `provided_index -> new_index` mapping.
+    /// I.e.: the `i`th unique `provided_index` in `ngram_tuples` is mapped to the `new_index` `i`.
+    ///
     /// Panics when there are duplicate ngrams.
-    pub fn new_with_indices(ngram_tuples: impl IntoIterator<Item = (String, u64)>) -> Self {
+    pub fn new_with_indices(
+        ngram_tuples: impl IntoIterator<Item = (String, u64)>,
+    ) -> (Self, HashMap<u64, usize>) {
         let ngram_tuples = ngram_tuples.into_iter();
         let mut old_to_new_indices = HashMap::with_capacity(ngram_tuples.size_hint().0);
         let mut index = HashMap::with_capacity(ngram_tuples.size_hint().0);
@@ -201,11 +206,14 @@ impl ExplicitIndexer {
             ngrams.push(ngram);
         }
         let bound = old_to_new_indices.len();
-        ExplicitIndexer {
-            ngrams,
-            index,
-            bound,
-        }
+        (
+            ExplicitIndexer {
+                ngrams,
+                index,
+                bound,
+            },
+            old_to_new_indices,
+        )
     }
 }
 


### PR DESCRIPTION
There is a small public API change included:

`ExplicitIndexer::new_with_indices()` now also returns the `old_to_new`mapping. Otherwise it's much more involved to figure out which bucket was moved to which index.

I'll add a new `pub (crate)` constructor if you prefer to keep the API stable.