### PR TITLE
Switch from memmap to memmap2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,10 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
+          command: check
+          args: --all-targets
+      - uses: actions-rs/cargo@v1
+        with:
           command: test
 
   test-cross:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,13 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 toml = "0.5"
 
-[dependencies.memmap]
-version = "0.7"
+[dependencies.memmap2]
+version = "0.3"
 optional = true
 
 [features]
 default = ["memmap"]
+memmap = ["memmap2"]
 
 [dev-dependencies]
 approx = "0.4"
@@ -53,4 +54,3 @@ harness = false
 [[bench]]
 name = "quantized"
 harness = false
-

--- a/benches/subword.rs
+++ b/benches/subword.rs
@@ -19,10 +19,8 @@ fn subwords(string: &str, min_n: usize, max_n: usize, indexer: &impl Indexer) ->
 
 fn ngrams_benchmark(c: &mut Criterion) {
     let rng = thread_rng();
-    let string = rng
-        .sample_iter(&Alphanumeric)
-        .take(WORD_LENGTH)
-        .collect::<String>();
+    let string =
+        String::from_utf8(rng.sample_iter(&Alphanumeric).take(WORD_LENGTH).collect()).unwrap();
 
     let indexer = FinalfusionHashIndexer::new(21);
 

--- a/src/chunks/storage/array.rs
+++ b/src/chunks/storage/array.rs
@@ -23,7 +23,7 @@ mod mmap {
     #[cfg(target_endian = "big")]
     use byteorder::ByteOrder;
     use byteorder::{LittleEndian, ReadBytesExt};
-    use memmap::{Mmap, MmapOptions};
+    use memmap2::{Mmap, MmapOptions};
     use ndarray::{Array2, ArrayView2, Axis, CowArray, Ix1};
     use ndarray::{Dimension, Ix2};
 
@@ -152,7 +152,7 @@ mod mmap {
                 mmap_opts
                     .offset(offset)
                     .len(matrix_len)
-                    .map(&read.get_ref())
+                    .map(&*read.get_ref())
                     .map_err(|e| Error::io_error("Cannot memory map embedding matrix", e))?
             };
 

--- a/src/chunks/storage/quantized.rs
+++ b/src/chunks/storage/quantized.rs
@@ -479,7 +479,7 @@ mod mmap {
     use std::fs::File;
     use std::io::{BufReader, Seek, SeekFrom, Write};
 
-    use memmap::{Mmap, MmapOptions};
+    use memmap2::{Mmap, MmapOptions};
     use ndarray::{Array1, Array2, ArrayView2, Axis, CowArray, Ix1};
     use reductive::pq::{QuantizeVector, ReconstructVector, PQ};
 
@@ -528,7 +528,7 @@ mod mmap {
                 mmap_opts
                     .offset(offset)
                     .len(matrix_len)
-                    .map(&read.get_ref())
+                    .map(&*read.get_ref())
                     .map_err(|e| {
                         Error::io_error("Cannot memory map quantized embedding matrix", e)
                     })?


### PR DESCRIPTION
memmap is no longer maintained, and the RustSec advisory DB issues a warning
when it appears in your dependency graph. memmap2 is a fork that is being
maintained, and is substantially more popular than the other suggested
alternative.