### PR TITLE
Add support for Floret embeddings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.53.0
+          toolchain: 1.54.0
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,14 @@ exclude = [
 byteorder = "1"
 fnv = "1"
 itertools = "0.10"
+murmur3 = "0.5"
 ndarray = "0.15"
 ordered-float = "2"
 rand = "0.8"
 rand_chacha = "0.3"
 reductive = "0.7"
 serde = { version = "1", features = ["derive"] }
+smallvec = "1.7"
 thiserror = "1"
 toml = "0.5"
 

--- a/src/chunks/vocab/mod.rs
+++ b/src/chunks/vocab/mod.rs
@@ -9,8 +9,8 @@ use crate::error::{Error, Result};
 
 mod subword;
 pub use subword::{
-    BucketSubwordVocab, ExplicitSubwordVocab, FastTextSubwordVocab, NGramIndices, SubwordIndices,
-    SubwordVocab,
+    BucketSubwordVocab, ExplicitSubwordVocab, FastTextSubwordVocab, FloretSubwordVocab,
+    IndicesScope, NGramIndices, SubwordIndices, SubwordVocab,
 };
 
 mod simple;

--- a/src/chunks/vocab/subword.rs
+++ b/src/chunks/vocab/subword.rs
@@ -601,7 +601,7 @@ where
         if indices.len() > 1 {
             return Err(Error::io_error(
                 format!(
-                    "Indexer maps n-gram to multipli indices during serialization: {}",
+                    "Indexer maps n-gram to multiple indices during serialization: {}",
                     ngram
                 ),
                 io::ErrorKind::Other.into(),

--- a/src/compat/fasttext/indexer.rs
+++ b/src/compat/fasttext/indexer.rs
@@ -1,6 +1,8 @@
 use std::i32;
 
-use crate::subword::{BucketIndexer, Indexer, StrWithCharLen};
+use smallvec::smallvec;
+
+use crate::subword::{BucketIndexer, Indexer, NGramVec, StrWithCharLen};
 
 /// fastText-compatible subword indexer.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -41,8 +43,9 @@ impl BucketIndexer for FastTextIndexer {
 }
 
 impl Indexer for FastTextIndexer {
-    fn index_ngram(&self, ngram: &StrWithCharLen) -> Option<u64> {
-        Some(u64::from(fasttext_hash(ngram.as_str()) % self.buckets))
+    fn index_ngram(&self, ngram: &StrWithCharLen) -> NGramVec {
+        let index = u64::from(fasttext_hash(ngram.as_str()) % self.buckets);
+        smallvec![index]
     }
 
     fn upper_bound(&self) -> u64 {

--- a/src/compat/fasttext/io.rs
+++ b/src/compat/fasttext/io.rs
@@ -15,6 +15,7 @@ use crate::embeddings::Embeddings;
 use crate::error::{Error, Result};
 use crate::subword::BucketIndexer;
 use crate::util::{l2_normalize_array, read_string};
+use crate::vocab::IndicesScope;
 
 use super::FastTextIndexer;
 
@@ -407,7 +408,7 @@ impl Model {
 /// adds the subword embeddings.
 fn add_subword_embeddings(vocab: &FastTextSubwordVocab, embeds: &mut NdArray) {
     for (idx, word) in vocab.words().iter().enumerate() {
-        if let Some(indices) = vocab.subword_indices(word) {
+        if let Some(indices) = vocab.subword_indices(word, IndicesScope::Subwords) {
             let n_embeds = indices.len() + 1;
 
             // Sum the embedding and its subword embeddings.
@@ -472,7 +473,7 @@ where
         let mut unnormalized_embedding =
             embedding_with_norm.embedding.mul(embedding_with_norm.norm);
 
-        if let Some(subword_indices) = vocab.subword_indices(word) {
+        if let Some(subword_indices) = vocab.subword_indices(word, IndicesScope::Subwords) {
             unnormalized_embedding *= (subword_indices.len() + 1) as f32;
 
             for subword_index in subword_indices {
@@ -554,6 +555,7 @@ where
         config.min_n,
         config.max_n,
         FastTextIndexer::new(config.bucket as usize),
+        IndicesScope::Subwords,
     ))
 }
 

--- a/src/compat/floret/indexer.rs
+++ b/src/compat/floret/indexer.rs
@@ -1,0 +1,63 @@
+use std::io::Cursor;
+
+use murmur3::murmur3_x64_128;
+use smallvec::smallvec;
+
+use crate::subword::{Indexer, NGramVec, StrWithCharLen};
+
+/// floret subword indexer.
+///
+/// By default, floret does not use a separate word embedding matrix. Every
+/// n-gram and the full word is mapped to 1 to 4 hash functions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FloretIndexer {
+    n_buckets: u64,
+    seed: u32,
+    n_hashes: u32,
+}
+
+impl FloretIndexer {
+    pub fn new(n_buckets: u64, n_hashes: u32, seed: u32) -> Self {
+        assert!(
+            n_hashes > 0 && n_hashes <= 4,
+            "Floret indexer needs 1 to 4 hashes, got {}",
+            n_hashes
+        );
+
+        assert_ne!(n_buckets, 0, "Floret needs at least 1 bucket.");
+
+        Self {
+            n_buckets,
+            n_hashes,
+            seed,
+        }
+    }
+}
+
+impl Indexer for FloretIndexer {
+    fn index_ngram(&self, ngram: &StrWithCharLen) -> NGramVec {
+        let hash = murmur3_x64_128(&mut Cursor::new(ngram.as_bytes()), self.seed)
+            .expect("Murmur hash failed");
+
+        let mut hash_array = [0; 4];
+        hash_array[0] = hash as u32;
+        hash_array[1] = (hash >> 32) as u32;
+        hash_array[2] = (hash >> 64) as u32;
+        hash_array[3] = (hash >> 96) as u32;
+
+        let mut indices = smallvec![0; self.n_hashes as usize];
+        for i in 0..self.n_hashes as usize {
+            indices[i] = hash_array[i] as u64 % self.n_buckets;
+        }
+
+        indices
+    }
+
+    fn upper_bound(&self) -> u64 {
+        self.n_buckets
+    }
+
+    fn infallible() -> bool {
+        true
+    }
+}

--- a/src/compat/floret/io.rs
+++ b/src/compat/floret/io.rs
@@ -1,0 +1,207 @@
+use std::io::BufRead;
+
+use ndarray::Array2;
+
+use crate::chunks::storage::NdArray;
+use crate::compat::floret::FloretIndexer;
+use crate::embeddings::Embeddings;
+use crate::error::{Error, Result};
+use crate::util::{read_number, read_string};
+use crate::vocab::{FloretSubwordVocab, IndicesScope};
+
+/// Read embeddings in the floret format.
+///
+/// More information about how floret embeddings can be found at:
+///
+/// https://github.com/explosion/floret#how-floret-works
+pub trait ReadFloretText
+where
+    Self: Sized,
+{
+    /// Read embeddings in the floret format.
+    fn read_floret_text(reader: &mut impl BufRead) -> Result<Self>;
+}
+
+impl ReadFloretText for Embeddings<FloretSubwordVocab, NdArray> {
+    fn read_floret_text(reader: &mut impl BufRead) -> Result<Self> {
+        let n_buckets = read_number(reader, b' ')?;
+        let embed_len = read_number(reader, b' ')?;
+        let min_n = read_number(reader, b' ')? as u32;
+        let max_n = read_number(reader, b' ')? as u32;
+        let n_hashes = read_number(reader, b' ')? as u32;
+        let hash_seed = read_number(reader, b' ')?;
+        let bow = read_string(reader, b' ', false)?;
+        let eow = read_string(reader, b'\n', false)?;
+
+        if n_buckets == 0 {
+            return Err(Error::Format("Expected at least 1 bucket".to_string()));
+        }
+
+        if embed_len == 0 {
+            return Err(Error::Format(
+                "Embeddings should have at least 1 dimension".to_string(),
+            ));
+        }
+
+        if min_n > max_n {
+            return Err(Error::Format(format!(
+                "The minimum n-gram length ({}) must not be larger than the maximum length ({})",
+                min_n, max_n
+            )));
+        }
+
+        if !(1..=4).contains(&n_hashes) {
+            return Err(Error::Format(format!(
+                "The number of hashes should be between 1 and 4 (inclusive), was: {}",
+                n_hashes
+            )));
+        }
+
+        let mut data = Vec::with_capacity(n_buckets * embed_len);
+
+        let mut prev_len = 0;
+        for line in reader.lines() {
+            let line = line.map_err(|err| Error::io_error("Cannot read line", err))?;
+
+            let parts = line
+                .split(|c: char| c.is_ascii_whitespace())
+                .filter(|part| !part.is_empty());
+
+            // Skip the first column, which is the embedding index.
+            for part in parts.skip(1) {
+                data.push(part.parse().map_err(|e| {
+                    Error::Format(format!("Cannot parse vector component '{}': {}", part, e))
+                })?);
+            }
+
+            if data.len() - prev_len != embed_len {
+                return Err(Error::Format(format!(
+                    "Incorrect number of embedding components, expected: {}, got: {}",
+                    embed_len,
+                    data.len() - prev_len
+                )));
+            }
+
+            prev_len += embed_len;
+        }
+
+        let matrix = Array2::from_shape_vec((n_buckets, embed_len), data).map_err(Error::Shape)?;
+
+        let indexer = FloretIndexer::new(n_buckets as u64, n_hashes, hash_seed as u32);
+
+        Ok(Embeddings::new_with_maybe_norms(
+            None,
+            FloretSubwordVocab::new_with_boundaries(
+                Vec::new(),
+                min_n,
+                max_n,
+                indexer,
+                IndicesScope::WordAndSubword,
+                bow,
+                eow,
+            ),
+            NdArray::new(matrix),
+            None,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use approx::assert_abs_diff_eq;
+
+    use super::ReadFloretText;
+    use crate::compat::text::ReadTextDims;
+    use crate::embeddings::Embeddings;
+
+    fn floret_embeds_small_text() -> &'static str {
+        // Example from spaCy tests.
+        "10 10 2 3 2 2166136261 < >
+0 -2.2611 3.9302 2.6676 -11.233 0.093715 -10.52 -9.6463 -0.11853 2.101 -0.10145
+1 -3.12 -1.7981 10.7 -6.171 4.4527 10.967 9.073 6.2056 -6.1199 -2.0402
+2 9.5689 5.6721 -8.4832 -1.2249 2.1871 -3.0264 -2.391 -5.3308 -3.2847 -4.0382
+3 3.6268 4.2759 -1.7007 1.5002 5.5266 1.8716 -12.063 0.26314 2.7645 2.4929
+4 -11.683 -7.7068 2.1102 2.214 7.2202 0.69799 3.2173 -5.382 -2.0838 5.0314
+5 -4.3024 8.0241 2.0714 -1.0174 -0.28369 1.7622 7.8797 -1.7795 6.7541 5.6703
+6 8.3574 -5.225 8.6529 8.5605 -8.9465 3.767 -5.4636 -1.4635 -0.98947 -0.58025
+7 -10.01 3.3894 -4.4487 1.1669 -11.904 6.5158 4.3681 0.79913 -6.9131 -8.687
+8 -5.4576 7.1019 -8.8259 1.7189 4.955 -8.9157 -3.8905 -0.60086 -2.1233 5.892
+9 8.0678 -4.4142 3.6236 4.5889 -2.7611 2.4455 0.67096 -4.2822 2.0875 4.6274"
+    }
+
+    fn floret_embeds_square_brackets() -> &'static str {
+        "10 10 2 3 2 2166136261 [ ]
+0 -2.2611 3.9302 2.6676 -11.233 0.093715 -10.52 -9.6463 -0.11853 2.101 -0.10145
+1 -3.12 -1.7981 10.7 -6.171 4.4527 10.967 9.073 6.2056 -6.1199 -2.0402
+2 9.5689 5.6721 -8.4832 -1.2249 2.1871 -3.0264 -2.391 -5.3308 -3.2847 -4.0382
+3 3.6268 4.2759 -1.7007 1.5002 5.5266 1.8716 -12.063 0.26314 2.7645 2.4929
+4 -11.683 -7.7068 2.1102 2.214 7.2202 0.69799 3.2173 -5.382 -2.0838 5.0314
+5 -4.3024 8.0241 2.0714 -1.0174 -0.28369 1.7622 7.8797 -1.7795 6.7541 5.6703
+6 8.3574 -5.225 8.6529 8.5605 -8.9465 3.767 -5.4636 -1.4635 -0.98947 -0.58025
+7 -10.01 3.3894 -4.4487 1.1669 -11.904 6.5158 4.3681 0.79913 -6.9131 -8.687
+8 -5.4576 7.1019 -8.8259 1.7189 4.955 -8.9157 -3.8905 -0.60086 -2.1233 5.892
+9 8.0678 -4.4142 3.6236 4.5889 -2.7611 2.4455 0.67096 -4.2822 2.0875 4.6274"
+    }
+
+    fn check_embeds() -> &'static str {
+        "10 10
+, -5.7814 2.6918 0.57029 -3.6985 -2.7079 1.4406 1.0084 1.7463 -3.8625 -3.0565
+. 3.8016 -1.759 0.59118 3.3044 -0.72975 0.45221 -2.1412 -3.8933 -2.1238 -0.47409
+der 0.08224 2.6601 -1.173 1.1549 -0.42821 -0.097268 -2.5589 -1.609 -0.16968 0.84687
+die -2.8781 0.082576 1.9286 -0.33279 0.79488 3.36 3.5609 -0.64328 -2.4152 0.17266
+und 2.1558 1.8606 -1.382 0.45424 -0.65889 1.2706 0.5929 -2.0592 -2.6949 -1.6015
+\" -1.1242 1.4588 -1.6263 1.0382 -2.7609 -0.99794 -0.83478 -1.5711 -1.2137 1.0239
+in -0.87635 2.0958 4.0018 -2.2473 -1.2429 2.3474 1.8846 0.46521 -0.506 -0.26653
+von -0.10589 1.196 1.1143 -0.40907 -1.0848 -0.054756 -2.5016 -1.0381 -0.41598 0.36982
+( 0.59263 2.1856 0.67346 1.0769 1.0701 1.2151 1.718 -3.0441 2.7291 3.719
+) 0.13812 3.3267 1.657 0.34729 -3.5459 0.72372 0.63034 -1.6145 1.2733 0.37798"
+    }
+
+    fn check_embeds_square_brackets() -> &'static str {
+        "10 10
+, 1.3844874 2.3464875 1.2599748 -0.6150249 -2.7724452 -0.79785013 -4.0532503 -1.1515112 0.19298255 -0.7406751
+. 5.3217626 2.0444875 -2.7715 2.684125 -0.52285004 -2.1163874 -3.1512802 -3.050415 -1.7490175 0.39203754
+der -0.30920622 3.038363 -0.68778753 -0.563806 1.5502453 -0.06880643 -1.2151338 -0.047910027 -1.5533295 0.95536256
+die -2.2371624 0.43071893 1.4706686 -0.67453104 1.2487259 2.3045924 0.17036629 0.23663676 -2.5797918 0.075331196
+und 0.24818125 2.7903755 0.3526249 0.09495008 -2.0179207 0.23948678 -0.71544373 -1.95366 0.3281494 -0.07667194
+\" -2.6215875 3.4702003 -0.0053626 -3.4728873 2.9032319 -4.2840385 -5.7323003 -0.9489587 1.7973748 2.659394
+in 1.3580999 2.151925 0.028333127 -1.8494834 1.0040858 0.08962494 -2.3529234 -0.5272758 -1.1616334 -0.076175064
+von -1.6226685 -0.16304988 2.0203125 -0.8460312 -0.5596545 2.6361988 -0.19833624 -0.30120564 -2.102173 -0.793722
+( -5.6849623 -0.17611253 -1.6755875 2.0539 -4.991875 3.5249727 2.00655 -1.7952224 -4.5117707 -3.6629562
+) -3.4659 3.5374627 -2.0717626 0.44365007 -1.2155627 3.4016874 -2.2377748 1.0989438 -2.586125 -1.8413126"
+    }
+
+    #[test]
+    fn test_floret_against_known() {
+        let check_embeds_text = check_embeds();
+        let check_embeds = Embeddings::read_text_dims(&mut Cursor::new(check_embeds_text)).unwrap();
+
+        let floret_embeds_text = floret_embeds_small_text();
+        let floret_embeds =
+            Embeddings::read_floret_text(&mut Cursor::new(floret_embeds_text)).unwrap();
+
+        for (word, check_embedding) in check_embeds.iter() {
+            let floret_embedding = floret_embeds.embedding(word).unwrap();
+
+            assert_abs_diff_eq!(floret_embedding, check_embedding, epsilon = 1e-4);
+        }
+    }
+
+    #[test]
+    fn test_floret_non_standard_brackets() {
+        let check_embeds_text = check_embeds_square_brackets();
+        let check_embeds = Embeddings::read_text_dims(&mut Cursor::new(check_embeds_text)).unwrap();
+
+        let floret_embeds_text = floret_embeds_square_brackets();
+        let floret_embeds =
+            Embeddings::read_floret_text(&mut Cursor::new(floret_embeds_text)).unwrap();
+
+        for (word, check_embedding) in check_embeds.iter() {
+            let floret_embedding = floret_embeds.embedding(word).unwrap();
+
+            assert_abs_diff_eq!(floret_embedding, check_embedding, epsilon = 1e-4);
+        }
+    }
+}

--- a/src/compat/floret/mod.rs
+++ b/src/compat/floret/mod.rs
@@ -1,0 +1,16 @@
+//! Support for the floret embedding format.
+//!
+//! More information about floret can be found at:
+//! https://github.com/explosion/floret#how-floret-works
+//!
+//! floret differs from finalfusion/fasttext embeddings in the
+//! following ways:
+//!
+//! * No separate embeddings are stored for words.
+//! * The word and its n-grams are mapped to 1-4 buckets.
+
+mod io;
+pub use io::ReadFloretText;
+
+mod indexer;
+pub use indexer::FloretIndexer;

--- a/src/compat/mod.rs
+++ b/src/compat/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod fasttext;
 
+pub mod floret;
+
 pub mod text;
 
 pub mod word2vec;

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,10 @@ pub enum Error {
     #[error("Invalid file format {0}")]
     Format(String),
 
+    /// Conversion of n-grams from implicit to explicit.
+    #[error("{0}")]
+    NGramConversionError(String),
+
     /// Random number generation error.
     #[error(transparent)]
     RandError(#[from] RandError),
@@ -39,6 +43,10 @@ pub enum Error {
 }
 
 impl Error {
+    pub fn ngram_conversion_error(desc: impl Into<String>) -> Self {
+        Error::NGramConversionError(desc.into())
+    }
+
     pub fn io_error(desc: impl Into<String>, error: io::Error) -> Self {
         Error::Io {
             desc: desc.into(),


### PR DESCRIPTION
Add support for reading and using Floret embeddings. Floret combines subword
embeddings with Bloom embeddings:

https://github.com/explosion/floret#how-floret-works

This allows Floret embedding matrices to be compact like Bloom embeddings,
while also using subword units.

Supporting Floret embeddings requires some architectural changes to
finalfusion:

1. ngrams -> index mappings are many-to-many

   finalfusion assumed that each n-gram maps to a single index. In Floret
   embeddings, an n-gram can map to multiple embeddings. finalfusion is
   extended in this change to support returning multiple indices for an
   n-gram.

2. Floret also hashes the word itself, not just the subwords. This change
   adds a boolean flag. If it is enabled, the word itself is also hashed,
   and its index is returned.

3. Floret permits different begin/end-of-word markers. These are made
   configurable for subword vocabs.