### PR TITLE
WriteFloretText: write correct number of buckets in header

### DIFF
--- a/src/compat/floret/io.rs
+++ b/src/compat/floret/io.rs
@@ -122,7 +122,7 @@ impl WriteFloretText for Embeddings<FloretSubwordVocab, NdArray> {
         writeln!(
             write,
             "{} {} {} {} {} {} {} {}",
-            self.vocab().vocab_len(),
+            self.vocab().vocab_len() - self.vocab().words_len(),
             self.dims(),
             self.vocab().min_n(),
             self.vocab().max_n(),


### PR DESCRIPTION
The size of the full vocabulary was written, rather than only the number
of buckets.