### PR TITLE
Improve indexing scope handling

### DIFF
--- a/src/chunks/vocab/mod.rs
+++ b/src/chunks/vocab/mod.rs
@@ -17,7 +17,6 @@ mod simple;
 pub use simple::SimpleVocab;
 
 mod wrappers;
-pub use crate::subword::IndicesScope;
 pub use wrappers::VocabWrap;
 
 /// Embedding vocabularies.

--- a/src/chunks/vocab/mod.rs
+++ b/src/chunks/vocab/mod.rs
@@ -10,13 +10,14 @@ use crate::error::{Error, Result};
 mod subword;
 pub use subword::{
     BucketSubwordVocab, ExplicitSubwordVocab, FastTextSubwordVocab, FloretSubwordVocab,
-    IndicesScope, NGramIndices, SubwordIndices, SubwordVocab,
+    NGramIndices, SubwordIndices, SubwordVocab,
 };
 
 mod simple;
 pub use simple::SimpleVocab;
 
 mod wrappers;
+pub use crate::subword::IndicesScope;
 pub use wrappers::VocabWrap;
 
 /// Embedding vocabularies.

--- a/src/compat/fasttext/indexer.rs
+++ b/src/compat/fasttext/indexer.rs
@@ -84,6 +84,7 @@ mod tests {
     use std::collections::HashMap;
     use std::iter::FromIterator;
 
+    use crate::chunks::vocab::IndicesScope;
     use lazy_static::lazy_static;
 
     use super::FastTextIndexer;
@@ -128,7 +129,9 @@ mod tests {
     fn subword_indices_test() {
         let indexer = FastTextIndexer::new(2_000_000);
         for (word, indices_check) in SUBWORD_TESTS.iter() {
-            let mut indices = word.subword_indices(3, 6, &indexer).collect::<Vec<_>>();
+            let mut indices = word
+                .subword_indices(3, 6, &indexer, IndicesScope::Substrings)
+                .collect::<Vec<_>>();
             indices.sort_unstable();
             assert_eq!(indices_check, &indices);
         }
@@ -138,7 +141,9 @@ mod tests {
     fn subword_indices_test_5_5() {
         let indexer = FastTextIndexer::new(2_000_000);
         for (word, indices_check) in SUBWORD_TESTS_5_5.iter() {
-            let mut indices = word.subword_indices(5, 5, &indexer).collect::<Vec<_>>();
+            let mut indices = word
+                .subword_indices(5, 5, &indexer, IndicesScope::Substrings)
+                .collect::<Vec<_>>();
             indices.sort_unstable();
             assert_eq!(indices_check, &indices);
         }

--- a/src/compat/fasttext/indexer.rs
+++ b/src/compat/fasttext/indexer.rs
@@ -2,7 +2,7 @@ use std::i32;
 
 use smallvec::smallvec;
 
-use crate::subword::{BucketIndexer, Indexer, NGramVec, StrWithCharLen};
+use crate::subword::{BucketIndexer, Indexer, IndicesScope, NGramVec, StrWithCharLen};
 
 /// fastText-compatible subword indexer.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -55,6 +55,10 @@ impl Indexer for FastTextIndexer {
     fn infallible() -> bool {
         true
     }
+
+    fn scope() -> IndicesScope {
+        IndicesScope::Substrings
+    }
 }
 
 /// fastText FNV-1a implementation.
@@ -84,7 +88,6 @@ mod tests {
     use std::collections::HashMap;
     use std::iter::FromIterator;
 
-    use crate::chunks::vocab::IndicesScope;
     use lazy_static::lazy_static;
 
     use super::FastTextIndexer;
@@ -129,9 +132,7 @@ mod tests {
     fn subword_indices_test() {
         let indexer = FastTextIndexer::new(2_000_000);
         for (word, indices_check) in SUBWORD_TESTS.iter() {
-            let mut indices = word
-                .subword_indices(3, 6, &indexer, IndicesScope::Substrings)
-                .collect::<Vec<_>>();
+            let mut indices = word.subword_indices(3, 6, &indexer).collect::<Vec<_>>();
             indices.sort_unstable();
             assert_eq!(indices_check, &indices);
         }
@@ -141,9 +142,7 @@ mod tests {
     fn subword_indices_test_5_5() {
         let indexer = FastTextIndexer::new(2_000_000);
         for (word, indices_check) in SUBWORD_TESTS_5_5.iter() {
-            let mut indices = word
-                .subword_indices(5, 5, &indexer, IndicesScope::Substrings)
-                .collect::<Vec<_>>();
+            let mut indices = word.subword_indices(5, 5, &indexer).collect::<Vec<_>>();
             indices.sort_unstable();
             assert_eq!(indices_check, &indices);
         }

--- a/src/compat/fasttext/io.rs
+++ b/src/compat/fasttext/io.rs
@@ -14,7 +14,6 @@ use crate::chunks::vocab::{FastTextSubwordVocab, SubwordIndices, Vocab};
 use crate::embeddings::Embeddings;
 use crate::error::{Error, Result};
 use crate::subword::BucketIndexer;
-use crate::subword::IndicesScope;
 use crate::util::{l2_normalize_array, read_string};
 
 use super::FastTextIndexer;
@@ -408,7 +407,7 @@ impl Model {
 /// adds the subword embeddings.
 fn add_subword_embeddings(vocab: &FastTextSubwordVocab, embeds: &mut NdArray) {
     for (idx, word) in vocab.words().iter().enumerate() {
-        if let Some(indices) = vocab.subword_indices(word, IndicesScope::Substrings) {
+        if let Some(indices) = vocab.subword_indices(word) {
             let n_embeds = indices.len() + 1;
 
             // Sum the embedding and its subword embeddings.
@@ -473,7 +472,7 @@ where
         let mut unnormalized_embedding =
             embedding_with_norm.embedding.mul(embedding_with_norm.norm);
 
-        if let Some(subword_indices) = vocab.subword_indices(word, IndicesScope::Substrings) {
+        if let Some(subword_indices) = vocab.subword_indices(word) {
             unnormalized_embedding *= (subword_indices.len() + 1) as f32;
 
             for subword_index in subword_indices {
@@ -555,7 +554,6 @@ where
         config.min_n,
         config.max_n,
         FastTextIndexer::new(config.bucket as usize),
-        IndicesScope::Substrings,
     ))
 }
 

--- a/src/compat/fasttext/io.rs
+++ b/src/compat/fasttext/io.rs
@@ -14,8 +14,8 @@ use crate::chunks::vocab::{FastTextSubwordVocab, SubwordIndices, Vocab};
 use crate::embeddings::Embeddings;
 use crate::error::{Error, Result};
 use crate::subword::BucketIndexer;
+use crate::subword::IndicesScope;
 use crate::util::{l2_normalize_array, read_string};
-use crate::vocab::IndicesScope;
 
 use super::FastTextIndexer;
 
@@ -408,7 +408,7 @@ impl Model {
 /// adds the subword embeddings.
 fn add_subword_embeddings(vocab: &FastTextSubwordVocab, embeds: &mut NdArray) {
     for (idx, word) in vocab.words().iter().enumerate() {
-        if let Some(indices) = vocab.subword_indices(word, IndicesScope::Subwords) {
+        if let Some(indices) = vocab.subword_indices(word, IndicesScope::Substrings) {
             let n_embeds = indices.len() + 1;
 
             // Sum the embedding and its subword embeddings.
@@ -473,7 +473,7 @@ where
         let mut unnormalized_embedding =
             embedding_with_norm.embedding.mul(embedding_with_norm.norm);
 
-        if let Some(subword_indices) = vocab.subword_indices(word, IndicesScope::Subwords) {
+        if let Some(subword_indices) = vocab.subword_indices(word, IndicesScope::Substrings) {
             unnormalized_embedding *= (subword_indices.len() + 1) as f32;
 
             for subword_index in subword_indices {
@@ -555,7 +555,7 @@ where
         config.min_n,
         config.max_n,
         FastTextIndexer::new(config.bucket as usize),
-        IndicesScope::Subwords,
+        IndicesScope::Substrings,
     ))
 }
 

--- a/src/compat/floret/indexer.rs
+++ b/src/compat/floret/indexer.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use murmur3::murmur3_x64_128;
 use smallvec::smallvec;
 
-use crate::subword::{Indexer, NGramVec, StrWithCharLen};
+use crate::subword::{Indexer, IndicesScope, NGramVec, StrWithCharLen};
 
 /// floret subword indexer.
 ///
@@ -67,5 +67,9 @@ impl Indexer for FloretIndexer {
 
     fn infallible() -> bool {
         true
+    }
+
+    fn scope() -> IndicesScope {
+        IndicesScope::StringAndSubstrings
     }
 }

--- a/src/compat/floret/io.rs
+++ b/src/compat/floret/io.rs
@@ -8,7 +8,6 @@ use crate::compat::floret::FloretIndexer;
 use crate::embeddings::Embeddings;
 use crate::error::{Error, Result};
 use crate::storage::StorageView;
-use crate::subword::IndicesScope;
 use crate::util::{read_number, read_string};
 use crate::vocab::{FloretSubwordVocab, Vocab};
 
@@ -94,15 +93,7 @@ impl ReadFloretText for Embeddings<FloretSubwordVocab, NdArray> {
 
         Ok(Embeddings::new_with_maybe_norms(
             None,
-            FloretSubwordVocab::new_with_boundaries(
-                Vec::new(),
-                min_n,
-                max_n,
-                indexer,
-                IndicesScope::StringAndSubstrings,
-                bow,
-                eow,
-            ),
+            FloretSubwordVocab::new_with_boundaries(Vec::new(), min_n, max_n, indexer, bow, eow),
             NdArray::new(matrix),
             None,
         ))

--- a/src/compat/floret/io.rs
+++ b/src/compat/floret/io.rs
@@ -8,8 +8,9 @@ use crate::compat::floret::FloretIndexer;
 use crate::embeddings::Embeddings;
 use crate::error::{Error, Result};
 use crate::storage::StorageView;
+use crate::subword::IndicesScope;
 use crate::util::{read_number, read_string};
-use crate::vocab::{FloretSubwordVocab, IndicesScope, Vocab};
+use crate::vocab::{FloretSubwordVocab, Vocab};
 
 /// Read embeddings in the floret format.
 ///
@@ -98,7 +99,7 @@ impl ReadFloretText for Embeddings<FloretSubwordVocab, NdArray> {
                 min_n,
                 max_n,
                 indexer,
-                IndicesScope::WordAndSubword,
+                IndicesScope::StringAndSubstrings,
                 bow,
                 eow,
             ),


### PR DESCRIPTION
This PR combines two changes:

* Move down `IndicesScope` handling to `SubwordIndices` trait. This is a better place to do this, because e.g. finalfrontier uses the `SubwordIndices` trait.
* Add the `Indexer::scope` method. This allows us to get the indexing scope from the indexer, rather than passing it around everywhere.