### PR TITLE
Improve error handling

### DIFF
--- a/src/chunks/io.rs
+++ b/src/chunks/io.rs
@@ -34,7 +34,7 @@ impl ChunkIdentifier {
     {
         let chunk_id = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read chunk identifier", e))?;
+            .map_err(|e| Error::read_error("Cannot read chunk identifier", e))?;
         let chunk_id = ChunkIdentifier::try_from(chunk_id)?;
         if chunk_id != identifier {
             return Err(Error::Format(format!(
@@ -107,7 +107,7 @@ macro_rules! typeid_impl {
             {
                 let type_id = read
                     .read_u32::<LittleEndian>()
-                    .map_err(|e| Error::io_error("Cannot read type identifier", e))?;
+                    .map_err(|e| Error::read_error("Cannot read type identifier", e))?;
                 if type_id != Self::type_id() {
                     return Err(Error::Format(format!(
                         "Invalid type, expected: {}, got: {}",
@@ -187,18 +187,18 @@ impl WriteChunk for Header {
     {
         write
             .write_all(&MAGIC)
-            .map_err(|e| Error::io_error("Cannot write magic", e))?;
+            .map_err(|e| Error::write_error("Cannot write magic", e))?;
         write
             .write_u32::<LittleEndian>(MODEL_VERSION)
-            .map_err(|e| Error::io_error("Cannot write model version", e))?;
+            .map_err(|e| Error::write_error("Cannot write model version", e))?;
         write
             .write_u32::<LittleEndian>(self.chunk_identifiers.len() as u32)
-            .map_err(|e| Error::io_error("Cannot write chunk identifiers length", e))?;
+            .map_err(|e| Error::write_error("Cannot write chunk identifiers length", e))?;
 
         for &identifier in &self.chunk_identifiers {
             write
                 .write_u32::<LittleEndian>(identifier as u32)
-                .map_err(|e| Error::io_error("Cannot write chunk identifier", e))?;
+                .map_err(|e| Error::write_error("Cannot write chunk identifier", e))?;
         }
 
         Ok(())
@@ -213,7 +213,7 @@ impl ReadChunk for Header {
         // Magic and version ceremony.
         let mut magic = [0u8; 4];
         read.read_exact(&mut magic)
-            .map_err(|e| Error::io_error("Cannot read magic", e))?;
+            .map_err(|e| Error::read_error("Cannot read magic", e))?;
 
         if magic != MAGIC {
             return Err(Error::Format(format!(
@@ -224,7 +224,7 @@ impl ReadChunk for Header {
 
         let version = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read model version", e))?;
+            .map_err(|e| Error::read_error("Cannot read model version", e))?;
         if version != MODEL_VERSION {
             return Err(Error::Format(format!(
                 "Unknown finalfusion version: {}",
@@ -235,13 +235,13 @@ impl ReadChunk for Header {
         // Read chunk identifiers.
         let chunk_identifiers_len = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read chunk identifiers length", e))?
+            .map_err(|e| Error::read_error("Cannot read chunk identifiers length", e))?
             as usize;
         let mut chunk_identifiers = Vec::with_capacity(chunk_identifiers_len);
         for _ in 0..chunk_identifiers_len {
             let identifier = read
                 .read_u32::<LittleEndian>()
-                .map_err(|e| Error::io_error("Cannot read chunk identifier", e))?;
+                .map_err(|e| Error::read_error("Cannot read chunk identifier", e))?;
             let chunk_identifier = ChunkIdentifier::try_from(identifier)?;
             chunk_identifiers.push(chunk_identifier);
         }

--- a/src/chunks/metadata.rs
+++ b/src/chunks/metadata.rs
@@ -53,14 +53,15 @@ impl ReadChunk for Metadata {
         ChunkIdentifier::ensure_chunk_type(read, ChunkIdentifier::Metadata)?;
 
         // Read chunk length.
-        let chunk_len =
-            read.read_u64::<LittleEndian>()
-                .map_err(|e| Error::io_error("Cannot read chunk length", e))? as usize;
+        let chunk_len = read
+            .read_u64::<LittleEndian>()
+            .map_err(|e| Error::read_error("Cannot read chunk length", e))?
+            as usize;
 
         // Read TOML data.
         let mut buf = vec![0; chunk_len];
         read.read_exact(&mut buf)
-            .map_err(|e| Error::io_error("Cannot read TOML metadata", e))?;
+            .map_err(|e| Error::read_error("Cannot read TOML metadata", e))?;
         let buf_str = String::from_utf8(buf)
             .map_err(|e| Error::Format(format!("TOML metadata contains invalid UTF-8: {}", e)))
             .map_err(Error::from)?;
@@ -87,13 +88,13 @@ impl WriteChunk for Metadata {
 
         write
             .write_u32::<LittleEndian>(self.chunk_identifier() as u32)
-            .map_err(|e| Error::io_error("Cannot write metadata chunk identifier", e))?;
+            .map_err(|e| Error::write_error("Cannot write metadata chunk identifier", e))?;
         write
             .write_u64::<LittleEndian>(metadata_str.len() as u64)
-            .map_err(|e| Error::io_error("Cannot write metadata length", e))?;
+            .map_err(|e| Error::write_error("Cannot write metadata length", e))?;
         write
             .write_all(metadata_str.as_bytes())
-            .map_err(|e| Error::io_error("Cannot write metadata", e))?;
+            .map_err(|e| Error::write_error("Cannot write metadata", e))?;
 
         Ok(())
     }

--- a/src/chunks/storage/wrappers.rs
+++ b/src/chunks/storage/wrappers.rs
@@ -127,15 +127,15 @@ impl ReadChunk for StorageWrap {
     {
         let chunk_start_pos = read
             .seek(SeekFrom::Current(0))
-            .map_err(|e| Error::io_error("Cannot get storage chunk start position", e))?;
+            .map_err(|e| Error::read_error("Cannot get storage chunk start position", e))?;
 
         let chunk_id = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read storage chunk identifier", e))?;
+            .map_err(|e| Error::read_error("Cannot read storage chunk identifier", e))?;
         let chunk_id = ChunkIdentifier::try_from(chunk_id)?;
 
         read.seek(SeekFrom::Start(chunk_start_pos))
-            .map_err(|e| Error::io_error("Cannot seek to storage chunk start position", e))?;
+            .map_err(|e| Error::read_error("Cannot seek to storage chunk start position", e))?;
 
         match chunk_id {
             ChunkIdentifier::NdArray => NdArray::read_chunk(read).map(StorageWrap::NdArray),
@@ -157,15 +157,15 @@ impl MmapChunk for StorageWrap {
     fn mmap_chunk(read: &mut BufReader<File>) -> Result<Self> {
         let chunk_start_pos = read
             .seek(SeekFrom::Current(0))
-            .map_err(|e| Error::io_error("Cannot get storage chunk start position", e))?;
+            .map_err(|e| Error::read_error("Cannot get storage chunk start position", e))?;
 
         let chunk_id = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read storage chunk identifier", e))?;
+            .map_err(|e| Error::read_error("Cannot read storage chunk identifier", e))?;
         let chunk_id = ChunkIdentifier::try_from(chunk_id)?;
 
         read.seek(SeekFrom::Start(chunk_start_pos))
-            .map_err(|e| Error::io_error("Cannot seek to storage chunk start position", e))?;
+            .map_err(|e| Error::read_error("Cannot seek to storage chunk start position", e))?;
 
         match chunk_id {
             ChunkIdentifier::NdArray => MmapArray::mmap_chunk(read).map(StorageWrap::MmapArray),
@@ -294,15 +294,15 @@ impl ReadChunk for StorageViewWrap {
     {
         let chunk_start_pos = read
             .seek(SeekFrom::Current(0))
-            .map_err(|e| Error::io_error("Cannot get storage chunk start position", e))?;
+            .map_err(|e| Error::read_error("Cannot get storage chunk start position", e))?;
 
         let chunk_id = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read storage chunk identifier", e))?;
+            .map_err(|e| Error::read_error("Cannot read storage chunk identifier", e))?;
         let chunk_id = ChunkIdentifier::try_from(chunk_id)?;
 
         read.seek(SeekFrom::Start(chunk_start_pos))
-            .map_err(|e| Error::io_error("Cannot seek to storage chunk start position", e))?;
+            .map_err(|e| Error::read_error("Cannot seek to storage chunk start position", e))?;
 
         match chunk_id {
             ChunkIdentifier::NdArray => NdArray::read_chunk(read).map(StorageViewWrap::NdArray),
@@ -341,15 +341,15 @@ impl MmapChunk for StorageViewWrap {
     fn mmap_chunk(read: &mut BufReader<File>) -> Result<Self> {
         let chunk_start_pos = read
             .seek(SeekFrom::Current(0))
-            .map_err(|e| Error::io_error("Cannot get storage chunk start position", e))?;
+            .map_err(|e| Error::read_error("Cannot get storage chunk start position", e))?;
 
         let chunk_id = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read storage chunk identifier", e))?;
+            .map_err(|e| Error::read_error("Cannot read storage chunk identifier", e))?;
         let chunk_id = ChunkIdentifier::try_from(chunk_id)?;
 
         read.seek(SeekFrom::Start(chunk_start_pos))
-            .map_err(|e| Error::io_error("Cannot seek to storage chunk start position", e))?;
+            .map_err(|e| Error::read_error("Cannot seek to storage chunk start position", e))?;
 
         match chunk_id {
             #[cfg(target_endian = "little")]

--- a/src/chunks/vocab/mod.rs
+++ b/src/chunks/vocab/mod.rs
@@ -81,10 +81,10 @@ where
 {
     let string_len =
         read.read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read string length", e))? as usize;
+            .map_err(|e| Error::read_error("Cannot read string length", e))? as usize;
     let mut bytes = vec![0; string_len];
     read.read_exact(&mut bytes)
-        .map_err(|e| Error::io_error("Cannot read item", e))?;
+        .map_err(|e| Error::read_error("Cannot read item", e))?;
     String::from_utf8(bytes)
         .map_err(|e| Error::Format(format!("Item contains invalid UTF-8: {}", e)))
         .map_err(Error::from)
@@ -108,10 +108,10 @@ where
 {
     write
         .write_u32::<LittleEndian>(s.len() as u32)
-        .map_err(|e| Error::io_error("Cannot write string length", e))?;
+        .map_err(|e| Error::write_error("Cannot write string length", e))?;
     write
         .write_all(s.as_bytes())
-        .map_err(|e| Error::io_error("Cannot write string", e))
+        .map_err(|e| Error::write_error("Cannot write string", e))
 }
 
 pub(crate) fn write_vocab_items<W>(write: &mut W, items: &[String]) -> Result<()>

--- a/src/chunks/vocab/simple.rs
+++ b/src/chunks/vocab/simple.rs
@@ -61,11 +61,11 @@ impl ReadChunk for SimpleVocab {
 
         // Read and discard chunk length.
         read.read_u64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read vocabulary chunk length", e))?;
+            .map_err(|e| Error::read_error("Cannot read vocabulary chunk length", e))?;
 
         let vocab_len = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read vocabulary length", e))?
+            .map_err(|e| Error::read_error("Cannot read vocabulary length", e))?
             .try_into()
             .map_err(|_| Error::Overflow)?;
 
@@ -95,13 +95,13 @@ impl WriteChunk for SimpleVocab {
 
         write
             .write_u32::<LittleEndian>(ChunkIdentifier::SimpleVocab as u32)
-            .map_err(|e| Error::io_error("Cannot write vocabulary chunk identifier", e))?;
+            .map_err(|e| Error::write_error("Cannot write vocabulary chunk identifier", e))?;
         write
             .write_u64::<LittleEndian>(chunk_len as u64)
-            .map_err(|e| Error::io_error("Cannot write vocabulary chunk length", e))?;
+            .map_err(|e| Error::write_error("Cannot write vocabulary chunk length", e))?;
         write
             .write_u64::<LittleEndian>(self.words.len() as u64)
-            .map_err(|e| Error::io_error("Cannot write vocabulary length", e))?;
+            .map_err(|e| Error::write_error("Cannot write vocabulary length", e))?;
 
         write_vocab_items(write, self.words())?;
 

--- a/src/chunks/vocab/subword.rs
+++ b/src/chunks/vocab/subword.rs
@@ -349,21 +349,21 @@ where
 
         // Read and discard chunk length.
         read.read_u64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read vocabulary chunk length", e))?;
+            .map_err(|e| Error::read_error("Cannot read vocabulary chunk length", e))?;
 
         let vocab_len = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read vocabulary length", e))?
+            .map_err(|e| Error::read_error("Cannot read vocabulary length", e))?
             as usize;
         let min_n = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read minimum n-gram length", e))?;
+            .map_err(|e| Error::read_error("Cannot read minimum n-gram length", e))?;
         let max_n = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read maximum n-gram length", e))?;
+            .map_err(|e| Error::read_error("Cannot read maximum n-gram length", e))?;
         let buckets = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read number of buckets", e))?;
+            .map_err(|e| Error::read_error("Cannot read number of buckets", e))?;
 
         let words = read_vocab_items(read, vocab_len as usize)?;
 
@@ -399,22 +399,24 @@ where
 
         write
             .write_u32::<LittleEndian>(chunk_identifier as u32)
-            .map_err(|e| Error::io_error("Cannot write subword vocabulary chunk identifier", e))?;
+            .map_err(|e| {
+                Error::write_error("Cannot write subword vocabulary chunk identifier", e)
+            })?;
         write
             .write_u64::<LittleEndian>(chunk_len as u64)
-            .map_err(|e| Error::io_error("Cannot write subword vocabulary chunk length", e))?;
+            .map_err(|e| Error::write_error("Cannot write subword vocabulary chunk length", e))?;
         write
             .write_u64::<LittleEndian>(self.words.len() as u64)
-            .map_err(|e| Error::io_error("Cannot write vocabulary length", e))?;
+            .map_err(|e| Error::write_error("Cannot write vocabulary length", e))?;
         write
             .write_u32::<LittleEndian>(self.min_n)
-            .map_err(|e| Error::io_error("Cannot write minimum n-gram length", e))?;
+            .map_err(|e| Error::write_error("Cannot write minimum n-gram length", e))?;
         write
             .write_u32::<LittleEndian>(self.max_n)
-            .map_err(|e| Error::io_error("Cannot write maximum n-gram length", e))?;
+            .map_err(|e| Error::write_error("Cannot write maximum n-gram length", e))?;
         write
             .write_u32::<LittleEndian>(self.indexer.buckets() as u32)
-            .map_err(|e| Error::io_error("Cannot write number of buckets", e))?;
+            .map_err(|e| Error::write_error("Cannot write number of buckets", e))?;
 
         write_vocab_items(write, self.words())?;
 
@@ -476,19 +478,19 @@ impl ExplicitSubwordVocab {
         ChunkIdentifier::ensure_chunk_type(read, chunk_identifier)?;
         // Read and discard chunk length.
         read.read_u64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read vocabulary chunk length", e))?;
+            .map_err(|e| Error::read_error("Cannot read vocabulary chunk length", e))?;
         let words_len = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read number of words", e))?;
+            .map_err(|e| Error::read_error("Cannot read number of words", e))?;
         let ngrams_len = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read number of ngrams", e))?;
+            .map_err(|e| Error::read_error("Cannot read number of ngrams", e))?;
         let min_n = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read minimum n-gram length", e))?;
+            .map_err(|e| Error::read_error("Cannot read minimum n-gram length", e))?;
         let max_n = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read maximum n-gram length", e))?;
+            .map_err(|e| Error::read_error("Cannot read maximum n-gram length", e))?;
 
         let words = read_vocab_items(read, words_len as usize)?;
         let ngrams = read_ngrams_with_indices(read, ngrams_len as usize)?;
@@ -523,22 +525,24 @@ impl ExplicitSubwordVocab {
 
         write
             .write_u32::<LittleEndian>(chunk_identifier as u32)
-            .map_err(|e| Error::io_error("Cannot write subword vocabulary chunk identifier", e))?;
+            .map_err(|e| {
+                Error::write_error("Cannot write subword vocabulary chunk identifier", e)
+            })?;
         write
             .write_u64::<LittleEndian>(chunk_len as u64)
-            .map_err(|e| Error::io_error("Cannot write subword vocabulary chunk length", e))?;
+            .map_err(|e| Error::write_error("Cannot write subword vocabulary chunk length", e))?;
         write
             .write_u64::<LittleEndian>(self.words.len() as u64)
-            .map_err(|e| Error::io_error("Cannot write vocabulary length", e))?;
+            .map_err(|e| Error::write_error("Cannot write vocabulary length", e))?;
         write
             .write_u64::<LittleEndian>(self.indexer.ngrams().len() as u64)
-            .map_err(|e| Error::io_error("Cannot write ngram length", e))?;
+            .map_err(|e| Error::write_error("Cannot write ngram length", e))?;
         write
             .write_u32::<LittleEndian>(self.min_n)
-            .map_err(|e| Error::io_error("Cannot write minimum n-gram length", e))?;
+            .map_err(|e| Error::write_error("Cannot write minimum n-gram length", e))?;
         write
             .write_u32::<LittleEndian>(self.max_n)
-            .map_err(|e| Error::io_error("Cannot write maximum n-gram length", e))?;
+            .map_err(|e| Error::write_error("Cannot write maximum n-gram length", e))?;
 
         write_vocab_items(write, self.words())?;
         write_ngrams_with_indices(write, self.indexer())?;
@@ -559,22 +563,22 @@ impl FloretSubwordVocab {
 
         // Read and discard chunk length.
         read.read_u64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read vocabulary chunk length", e))?;
+            .map_err(|e| Error::read_error("Cannot read vocabulary chunk length", e))?;
 
         let min_n = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read minimum n-gram length", e))?;
+            .map_err(|e| Error::read_error("Cannot read minimum n-gram length", e))?;
         let max_n = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read maximum n-gram length", e))?;
+            .map_err(|e| Error::read_error("Cannot read maximum n-gram length", e))?;
         let n_buckets = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read number of buckets", e))?;
+            .map_err(|e| Error::read_error("Cannot read number of buckets", e))?;
         let n_hashes: u32 = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read number of hashes", e))?;
+            .map_err(|e| Error::read_error("Cannot read number of hashes", e))?;
         if !(1..=4).contains(&n_hashes) {
-            return Err(Error::io_error(
+            return Err(Error::read_error(
                 format!(
                     "Number of hashes should be in be more than 0 and less than 5, was: {}",
                     n_hashes
@@ -584,7 +588,7 @@ impl FloretSubwordVocab {
         }
         let seed: u32 = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read hasher seed", e))?;
+            .map_err(|e| Error::read_error("Cannot read hasher seed", e))?;
         let bow = read_string(read).map_err(|e| e.context("Cannot read begin of word marker"))?;
         let eow = read_string(read).map_err(|e| e.context("Cannot read end of word marker"))?;
 
@@ -618,25 +622,27 @@ impl FloretSubwordVocab {
 
         write
             .write_u32::<LittleEndian>(chunk_identifier as u32)
-            .map_err(|e| Error::io_error("Cannot write subword vocabulary chunk identifier", e))?;
+            .map_err(|e| {
+                Error::write_error("Cannot write subword vocabulary chunk identifier", e)
+            })?;
         write
             .write_u64::<LittleEndian>(chunk_len as u64)
-            .map_err(|e| Error::io_error("Cannot write subword vocabulary chunk length", e))?;
+            .map_err(|e| Error::write_error("Cannot write subword vocabulary chunk length", e))?;
         write
             .write_u32::<LittleEndian>(self.min_n)
-            .map_err(|e| Error::io_error("Cannot write minimum n-gram length", e))?;
+            .map_err(|e| Error::write_error("Cannot write minimum n-gram length", e))?;
         write
             .write_u32::<LittleEndian>(self.max_n)
-            .map_err(|e| Error::io_error("Cannot write maximum n-gram length", e))?;
+            .map_err(|e| Error::write_error("Cannot write maximum n-gram length", e))?;
         write
             .write_u64::<LittleEndian>(self.indexer.n_buckets())
-            .map_err(|e| Error::io_error("Cannot write number of buckets", e))?;
+            .map_err(|e| Error::write_error("Cannot write number of buckets", e))?;
         write
             .write_u32::<LittleEndian>(self.indexer.n_hashes())
-            .map_err(|e| Error::io_error("Cannot write number of hashes", e))?;
+            .map_err(|e| Error::write_error("Cannot write number of hashes", e))?;
         write
             .write_u32::<LittleEndian>(self.indexer().seed())
-            .map_err(|e| Error::io_error("Cannot write hasher seed", e))?;
+            .map_err(|e| Error::write_error("Cannot write hasher seed", e))?;
         write_string(write, self.bow())
             .map_err(|e| e.context("Cannot write begin of word marker"))?;
         write_string(write, self.eow())
@@ -654,16 +660,16 @@ where
     for _ in 0..len {
         let ngram_len =
             read.read_u32::<LittleEndian>()
-                .map_err(|e| Error::io_error("Cannot read item length", e))? as usize;
+                .map_err(|e| Error::read_error("Cannot read item length", e))? as usize;
         let mut bytes = vec![0; ngram_len];
         read.read_exact(&mut bytes)
-            .map_err(|e| Error::io_error("Cannot read item", e))?;
+            .map_err(|e| Error::read_error("Cannot read item", e))?;
         let item = String::from_utf8(bytes)
             .map_err(|e| Error::Format(format!("Item contains invalid UTF-8: {}", e)))
             .map_err(Error::from)?;
         let idx = read
             .read_u64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read ngram index.", e))?;
+            .map_err(|e| Error::read_error("Cannot read ngram index.", e))?;
         ngrams.push((item, idx));
     }
     Ok(ngrams)
@@ -676,7 +682,7 @@ where
     for ngram in indexer.ngrams() {
         let indices = indexer.index_ngram(&ngram.as_str().into());
         if indices.is_empty() {
-            return Err(Error::io_error(
+            return Err(Error::write_error(
                 format!(
                     "Indexer could not index n-gram during serialization: {}",
                     ngram
@@ -686,7 +692,7 @@ where
         }
 
         if indices.len() > 1 {
-            return Err(Error::io_error(
+            return Err(Error::write_error(
                 format!(
                     "Indexer maps n-gram to multiple indices during serialization: {}",
                     ngram
@@ -699,13 +705,13 @@ where
 
         write
             .write_u32::<LittleEndian>(ngram.len() as u32)
-            .map_err(|e| Error::io_error("Cannot write ngram length", e))?;
+            .map_err(|e| Error::write_error("Cannot write ngram length", e))?;
         write
             .write_all(ngram.as_bytes())
-            .map_err(|e| Error::io_error("Cannot write ngram", e))?;
+            .map_err(|e| Error::write_error("Cannot write ngram", e))?;
         write
             .write_u64::<LittleEndian>(idx)
-            .map_err(|e| Error::io_error("Cannot write ngram idx", e))?;
+            .map_err(|e| Error::write_error("Cannot write ngram idx", e))?;
     }
     Ok(())
 }

--- a/src/chunks/vocab/wrappers.rs
+++ b/src/chunks/vocab/wrappers.rs
@@ -111,14 +111,14 @@ impl ReadChunk for VocabWrap {
     {
         let chunk_start_pos = read
             .seek(SeekFrom::Current(0))
-            .map_err(|e| Error::io_error("Cannot get vocabulary chunk start position", e))?;
+            .map_err(|e| Error::read_error("Cannot get vocabulary chunk start position", e))?;
         let chunk_id = read
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read vocabulary chunk identifier", e))?;
+            .map_err(|e| Error::read_error("Cannot read vocabulary chunk identifier", e))?;
         let chunk_id = ChunkIdentifier::try_from(chunk_id)?;
 
         read.seek(SeekFrom::Start(chunk_start_pos))
-            .map_err(|e| Error::io_error("Cannot seek to vocabulary chunk start position", e))?;
+            .map_err(|e| Error::read_error("Cannot seek to vocabulary chunk start position", e))?;
 
         match chunk_id {
             ChunkIdentifier::SimpleVocab => {

--- a/src/compat/fasttext/io.rs
+++ b/src/compat/fasttext/io.rs
@@ -61,7 +61,7 @@ impl ReadFastTextPrivate for Embeddings<FastTextSubwordVocab, NdArray> {
     fn read_fasttext_private(mut reader: &mut impl BufRead, lossy: bool) -> Result<Self> {
         let magic = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot fastText read magic", e))?;
+            .map_err(|e| Error::read_error("Cannot fastText read magic", e))?;
         if magic != FASTTEXT_FILEFORMAT_MAGIC {
             return Err(Error::Format(format!(
                 "Expected {} as magic, got: {}",
@@ -71,7 +71,7 @@ impl ReadFastTextPrivate for Embeddings<FastTextSubwordVocab, NdArray> {
 
         let version = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read fastText version", e))?;
+            .map_err(|e| Error::read_error("Cannot read fastText version", e))?;
         if version > FASTTEXT_VERSION {
             return Err(Error::Format(format!(
                 "Expected {} as version, got: {}",
@@ -85,7 +85,7 @@ impl ReadFastTextPrivate for Embeddings<FastTextSubwordVocab, NdArray> {
 
         let is_quantized = reader
             .read_u8()
-            .map_err(|e| Error::io_error("Cannot read quantization information", e))?;
+            .map_err(|e| Error::read_error("Cannot read quantization information", e))?;
         if is_quantized == 1 {
             return Err(Error::Format(
                 "Quantized fastText models are not supported".into(),
@@ -102,7 +102,7 @@ impl ReadFastTextPrivate for Embeddings<FastTextSubwordVocab, NdArray> {
 
         // Verify that vocab and storage shapes match.
         if storage.shape().0 != vocab.words_len() + config.bucket as usize {
-            return Err(Error::Shape(ShapeError::from_kind(
+            return Err(Error::MatrixShape(ShapeError::from_kind(
                 ShapeErrorKind::IncompatibleShape,
             )));
         }
@@ -159,10 +159,10 @@ where
 
         write
             .write_u32::<LittleEndian>(FASTTEXT_FILEFORMAT_MAGIC)
-            .map_err(|e| Error::io_error("Cannot write fastText magic", e))?;
+            .map_err(|e| Error::write_error("Cannot write fastText magic", e))?;
         write
             .write_u32::<LittleEndian>(FASTTEXT_VERSION)
-            .map_err(|e| Error::io_error("Cannot write fastText version", e))?;
+            .map_err(|e| Error::write_error("Cannot write fastText version", e))?;
 
         config.write(write)?;
 
@@ -170,7 +170,7 @@ where
 
         write
             .write_u8(0)
-            .map_err(|e| Error::io_error("Cannot write quantization status", e))?;
+            .map_err(|e| Error::write_error("Cannot write quantization status", e))?;
 
         write_embeddings(write, self)
     }
@@ -222,39 +222,39 @@ impl Config {
     {
         let dims = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read number of dimensions", e))?;
+            .map_err(|e| Error::read_error("Cannot read number of dimensions", e))?;
         let window_size = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read window size", e))?;
+            .map_err(|e| Error::read_error("Cannot read window size", e))?;
         let epoch = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read number of epochs", e))?;
+            .map_err(|e| Error::read_error("Cannot read number of epochs", e))?;
         let min_count = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read minimum count", e))?;
+            .map_err(|e| Error::read_error("Cannot read minimum count", e))?;
         let neg = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read negative samples", e))?;
+            .map_err(|e| Error::read_error("Cannot read negative samples", e))?;
         let word_ngrams = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read word n-gram length", e))?;
+            .map_err(|e| Error::read_error("Cannot read word n-gram length", e))?;
         let loss = Loss::read(reader)?;
         let model = Model::read(reader)?;
         let bucket = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read number of buckets", e))?;
+            .map_err(|e| Error::read_error("Cannot read number of buckets", e))?;
         let min_n = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read minimum subword length", e))?;
+            .map_err(|e| Error::read_error("Cannot read minimum subword length", e))?;
         let max_n = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read maximum subword length", e))?;
+            .map_err(|e| Error::read_error("Cannot read maximum subword length", e))?;
         let lr_update_rate = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read LR update rate", e))?;
+            .map_err(|e| Error::read_error("Cannot read LR update rate", e))?;
         let sampling_threshold = reader
             .read_f64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read sampling threshold", e))?;
+            .map_err(|e| Error::read_error("Cannot read sampling threshold", e))?;
 
         Ok(Config {
             dims,
@@ -279,39 +279,39 @@ impl Config {
     {
         write
             .write_u32::<LittleEndian>(self.dims)
-            .map_err(|e| Error::io_error("Cannot write number of dimensions", e))?;
+            .map_err(|e| Error::write_error("Cannot write number of dimensions", e))?;
         write
             .write_u32::<LittleEndian>(self.window_size)
-            .map_err(|e| Error::io_error("Cannot write window size", e))?;
+            .map_err(|e| Error::write_error("Cannot write window size", e))?;
         write
             .write_u32::<LittleEndian>(self.epoch)
-            .map_err(|e| Error::io_error("Cannot write number of epochs", e))?;
+            .map_err(|e| Error::write_error("Cannot write number of epochs", e))?;
         write
             .write_u32::<LittleEndian>(self.min_count)
-            .map_err(|e| Error::io_error("Cannot write minimum count", e))?;
+            .map_err(|e| Error::write_error("Cannot write minimum count", e))?;
         write
             .write_u32::<LittleEndian>(self.neg)
-            .map_err(|e| Error::io_error("Cannot write negative samples", e))?;
+            .map_err(|e| Error::write_error("Cannot write negative samples", e))?;
         write
             .write_u32::<LittleEndian>(self.word_ngrams)
-            .map_err(|e| Error::io_error("Cannot write word n-gram length", e))?;
+            .map_err(|e| Error::write_error("Cannot write word n-gram length", e))?;
         self.loss.write(write)?;
         self.model.write(write)?;
         write
             .write_u32::<LittleEndian>(self.bucket)
-            .map_err(|e| Error::io_error("Cannot write number of buckets", e))?;
+            .map_err(|e| Error::write_error("Cannot write number of buckets", e))?;
         write
             .write_u32::<LittleEndian>(self.min_n)
-            .map_err(|e| Error::io_error("Cannot write minimum subword length", e))?;
+            .map_err(|e| Error::write_error("Cannot write minimum subword length", e))?;
         write
             .write_u32::<LittleEndian>(self.max_n)
-            .map_err(|e| Error::io_error("Cannot write maximum subword length", e))?;
+            .map_err(|e| Error::write_error("Cannot write maximum subword length", e))?;
         write
             .write_u32::<LittleEndian>(self.lr_update_rate)
-            .map_err(|e| Error::io_error("Cannot write LR update rate", e))?;
+            .map_err(|e| Error::write_error("Cannot write LR update rate", e))?;
         write
             .write_f64::<LittleEndian>(self.sampling_threshold)
-            .map_err(|e| Error::io_error("Cannot write sampling threshold", e))
+            .map_err(|e| Error::write_error("Cannot write sampling threshold", e))
     }
 }
 
@@ -330,7 +330,7 @@ impl Loss {
     {
         let loss = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read loss type", e))?;
+            .map_err(|e| Error::read_error("Cannot read loss type", e))?;
 
         use self::Loss::*;
         match loss {
@@ -354,7 +354,7 @@ impl Loss {
 
         write
             .write_u32::<LittleEndian>(loss_id)
-            .map_err(|e| Error::io_error("Cannot write loss function", e))
+            .map_err(|e| Error::write_error("Cannot write loss function", e))
     }
 }
 
@@ -373,7 +373,7 @@ impl Model {
     {
         let model = reader
             .read_u32::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read model type", e))?;
+            .map_err(|e| Error::read_error("Cannot read model type", e))?;
 
         use self::Model::*;
         match model {
@@ -397,7 +397,7 @@ impl Model {
 
         write
             .write_u32::<LittleEndian>(model_id)
-            .map_err(|e| Error::io_error("Cannot write loss function", e))
+            .map_err(|e| Error::write_error("Cannot write loss function", e))
     }
 }
 
@@ -431,12 +431,12 @@ where
 {
     let m = reader
         .read_u64::<LittleEndian>()
-        .map_err(|e| Error::io_error("Cannot read number of embedding matrix rows", e))?
+        .map_err(|e| Error::read_error("Cannot read number of embedding matrix rows", e))?
         .try_into()
         .map_err(|_| Error::Overflow)?;
     let n = reader
         .read_u64::<LittleEndian>()
-        .map_err(|e| Error::io_error("Cannot read number of embedding matrix columns", e))?
+        .map_err(|e| Error::read_error("Cannot read number of embedding matrix columns", e))?
         .try_into()
         .map_err(|_| Error::Overflow)?;
 
@@ -444,7 +444,7 @@ where
     let mut data = Array2::zeros((m, n));
     reader
         .read_f32_into::<LittleEndian>(data.as_slice_mut().unwrap())
-        .map_err(|e| Error::io_error("Cannot read embeddings", e))?;
+        .map_err(|e| Error::read_error("Cannot read embeddings", e))?;
 
     Ok(NdArray::new(data))
 }
@@ -463,10 +463,10 @@ where
 
     write
         .write_u64::<LittleEndian>(storage.shape().0 as u64)
-        .map_err(|e| Error::io_error("Cannot write number of embedding matrix rows", e))?;
+        .map_err(|e| Error::write_error("Cannot write number of embedding matrix rows", e))?;
     write
         .write_u64::<LittleEndian>(storage.shape().1 as u64)
-        .map_err(|e| Error::io_error("Cannot write number of embedding matrix columns", e))?;
+        .map_err(|e| Error::write_error("Cannot write number of embedding matrix columns", e))?;
 
     for (word, embedding_with_norm) in embeddings.iter_with_norms() {
         let mut unnormalized_embedding =
@@ -483,7 +483,7 @@ where
         for v in &unnormalized_embedding {
             write
                 .write_f32::<LittleEndian>(*v)
-                .map_err(|e| Error::io_error("Cannot write embedding", e))?;
+                .map_err(|e| Error::write_error("Cannot write embedding", e))?;
         }
     }
 
@@ -492,7 +492,7 @@ where
         for v in storage.embedding(idx).view() {
             write
                 .write_f32::<LittleEndian>(*v)
-                .map_err(|e| Error::io_error("Cannot write subword embedding", e))?;
+                .map_err(|e| Error::write_error("Cannot write subword embedding", e))?;
         }
     }
 
@@ -506,14 +506,14 @@ where
 {
     let size = reader
         .read_u32::<LittleEndian>()
-        .map_err(|e| Error::io_error("Cannot read vocabulary size", e))?;
+        .map_err(|e| Error::read_error("Cannot read vocabulary size", e))?;
     reader
         .read_u32::<LittleEndian>()
-        .map_err(|e| Error::io_error("Cannot read number of words", e))?;
+        .map_err(|e| Error::read_error("Cannot read number of words", e))?;
 
     let n_labels = reader
         .read_u32::<LittleEndian>()
-        .map_err(|e| Error::io_error("Cannot number of labels", e))?;
+        .map_err(|e| Error::read_error("Cannot read number of labels", e))?;
     if n_labels > 0 {
         return Err(Error::Format(
             "fastText prediction models are not supported".into(),
@@ -522,11 +522,11 @@ where
 
     reader
         .read_u64::<LittleEndian>()
-        .map_err(|e| Error::io_error("Cannot read number of tokens", e))?;
+        .map_err(|e| Error::read_error("Cannot read number of tokens", e))?;
 
     let prune_idx_size = reader
         .read_i64::<LittleEndian>()
-        .map_err(|e| Error::io_error("Cannot read pruned vocabulary size", e))?;
+        .map_err(|e| Error::read_error("Cannot read pruned vocabulary size", e))?;
     if prune_idx_size >= 0 {
         return Err(Error::Format(
             "Pruned vocabularies are not supported".into(),
@@ -538,10 +538,10 @@ where
         let word = read_string(reader, 0, lossy)?;
         reader
             .read_u64::<LittleEndian>()
-            .map_err(|e| Error::io_error("Cannot read word frequency", e))?;
+            .map_err(|e| Error::read_error("Cannot read word frequency", e))?;
         let entry_type = reader
             .read_u8()
-            .map_err(|e| Error::io_error("Cannot read entry type", e))?;
+            .map_err(|e| Error::read_error("Cannot read entry type", e))?;
         if entry_type != 0 {
             return Err(Error::Format("Non-word entry".into()));
         }
@@ -565,33 +565,33 @@ where
     let words_len = vocab.words_len().try_into().map_err(|_| Error::Overflow)?;
     write
         .write_u32::<LittleEndian>(words_len)
-        .map_err(|e| Error::io_error("Cannot write vocabulary size", e))?;
+        .map_err(|e| Error::write_error("Cannot write vocabulary size", e))?;
     write
         .write_u32::<LittleEndian>(words_len)
-        .map_err(|e| Error::io_error("Cannot write number of words", e))?;
+        .map_err(|e| Error::write_error("Cannot write number of words", e))?;
     write
         .write_u32::<LittleEndian>(0)
-        .map_err(|e| Error::io_error("Cannot write number of labels", e))?;
+        .map_err(|e| Error::write_error("Cannot write number of labels", e))?;
     write
         .write_u64::<LittleEndian>(0)
-        .map_err(|e| Error::io_error("Cannot write number of tokens", e))?;
+        .map_err(|e| Error::write_error("Cannot write number of tokens", e))?;
     write
         .write_i64::<LittleEndian>(-1)
-        .map_err(|e| Error::io_error("Cannot write pruned vocabulary size", e))?;
+        .map_err(|e| Error::write_error("Cannot write pruned vocabulary size", e))?;
 
     for word in vocab.words() {
         write
             .write_all(word.as_bytes())
-            .map_err(|e| Error::io_error("Cannot write word", e))?;
+            .map_err(|e| Error::write_error("Cannot write word", e))?;
         write
             .write_u8(0)
-            .map_err(|e| Error::io_error("Cannot write word terminator", e))?;
+            .map_err(|e| Error::write_error("Cannot write word terminator", e))?;
         write
             .write_u64::<LittleEndian>(0)
-            .map_err(|e| Error::io_error("Cannot write word frequency", e))?;
+            .map_err(|e| Error::write_error("Cannot write word frequency", e))?;
         write
             .write_u8(0)
-            .map_err(|e| Error::io_error("Cannot read entry type", e))?;
+            .map_err(|e| Error::read_error("Cannot read entry type", e))?;
     }
 
     Ok(())

--- a/src/compat/floret/io.rs
+++ b/src/compat/floret/io.rs
@@ -63,7 +63,7 @@ impl ReadFloretText for Embeddings<FloretSubwordVocab, NdArray> {
 
         let mut prev_len = 0;
         for line in reader.lines() {
-            let line = line.map_err(|err| Error::io_error("Cannot read line", err))?;
+            let line = line.map_err(|err| Error::read_error("Cannot read line", err))?;
 
             let parts = line
                 .split(|c: char| c.is_ascii_whitespace())
@@ -87,7 +87,8 @@ impl ReadFloretText for Embeddings<FloretSubwordVocab, NdArray> {
             prev_len += embed_len;
         }
 
-        let matrix = Array2::from_shape_vec((n_buckets, embed_len), data).map_err(Error::Shape)?;
+        let matrix =
+            Array2::from_shape_vec((n_buckets, embed_len), data).map_err(Error::MatrixShape)?;
 
         let indexer = FloretIndexer::new(n_buckets as u64, n_hashes, hash_seed as u32);
 
@@ -123,7 +124,7 @@ impl WriteFloretText for Embeddings<FloretSubwordVocab, NdArray> {
             self.vocab().bow(),
             self.vocab().eow()
         )
-        .map_err(|e| Error::io_error("Cannot write floret embeddings metadata", e))?;
+        .map_err(|e| Error::write_error("Cannot write floret embeddings metadata", e))?;
 
         // Ensure that we are only writing part of the embedding matrix which is
         // used for floret embeddings. The storage may have word embeddings through
@@ -134,7 +135,7 @@ impl WriteFloretText for Embeddings<FloretSubwordVocab, NdArray> {
         for (idx, embed) in hash_matrix.outer_iter().enumerate() {
             let embed_str = embed.view().iter().map(ToString::to_string).join(" ");
             writeln!(write, "{} {}", idx, embed_str)
-                .map_err(|e| Error::io_error("Cannot write embedding", e))?;
+                .map_err(|e| Error::write_error("Cannot write embedding", e))?;
         }
 
         Ok(())

--- a/src/compat/text.rs
+++ b/src/compat/text.rs
@@ -206,7 +206,7 @@ where
         let mut buf = Vec::new();
         match reader
             .read_until(b'\n', &mut buf)
-            .map_err(|e| Error::io_error("Cannot read line from embedding file", e))?
+            .map_err(|e| Error::read_error("Cannot read line from embedding file", e))?
         {
             0 => break,
             n => {
@@ -263,7 +263,7 @@ where
         (words.len(), dims)
     };
 
-    let matrix = Array2::from_shape_vec(shape, data).map_err(Error::Shape)?;
+    let matrix = Array2::from_shape_vec(shape, data).map_err(Error::MatrixShape)?;
 
     Ok(Embeddings::new_with_maybe_norms(
         None,
@@ -307,7 +307,7 @@ where
 
             let embed_str = embed.view().iter().map(ToString::to_string).join(" ");
             writeln!(write, "{} {}", word, embed_str)
-                .map_err(|e| Error::io_error("Cannot write word embedding", e))?;
+                .map_err(|e| Error::write_error("Cannot write word embedding", e))?;
         }
 
         Ok(())
@@ -340,7 +340,7 @@ where
 {
     fn write_text_dims(&self, write: &mut W, unnormalize: bool) -> Result<()> {
         writeln!(write, "{} {}", self.vocab().words_len(), self.dims())
-            .map_err(|e| Error::io_error("Cannot write word embedding matrix shape", e))?;
+            .map_err(|e| Error::write_error("Cannot write word embedding matrix shape", e))?;
         self.write_text(write, unnormalize)
     }
 }

--- a/src/compat/word2vec.rs
+++ b/src/compat/word2vec.rs
@@ -104,7 +104,7 @@ where
                 .read_f32_into::<LittleEndian>(
                     embedding.as_slice_mut().expect("Matrix not contiguous"),
                 )
-                .map_err(|e| Error::io_error("Cannot read word embedding", e))?;
+                .map_err(|e| Error::read_error("Cannot read word embedding", e))?;
         }
 
         Ok(Embeddings::new_with_maybe_norms(
@@ -142,10 +142,10 @@ where
         W: Write,
     {
         writeln!(w, "{} {}", self.vocab().words_len(), self.dims())
-            .map_err(|e| Error::io_error("Cannot write word embedding matrix shape", e))?;
+            .map_err(|e| Error::write_error("Cannot write word embedding matrix shape", e))?;
 
         for (word, embed_norm) in self.iter_with_norms() {
-            write!(w, "{} ", word).map_err(|e| Error::io_error("Cannot write token", e))?;
+            write!(w, "{} ", word).map_err(|e| Error::write_error("Cannot write token", e))?;
 
             let embed = if unnormalize {
                 CowArray::from(embed_norm.into_unnormalized())
@@ -155,11 +155,11 @@ where
 
             for v in embed.view() {
                 w.write_f32::<LittleEndian>(*v)
-                    .map_err(|e| Error::io_error("Cannot write embedding component", e))?;
+                    .map_err(|e| Error::write_error("Cannot write embedding component", e))?;
             }
 
             w.write_all(&[0x0a])
-                .map_err(|e| Error::io_error("Cannot write embedding separator", e))?;
+                .map_err(|e| Error::write_error("Cannot write embedding separator", e))?;
         }
 
         Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -102,7 +102,7 @@ pub fn read_string(reader: &mut dyn BufRead, delim: u8, lossy: bool) -> Result<S
     let mut buf = Vec::new();
     reader
         .read_until(delim, &mut buf)
-        .map_err(|e| Error::io_error("Cannot read string", e))?;
+        .map_err(|e| Error::read_error("Cannot read string", e))?;
     buf.pop();
 
     let s = if lossy {


### PR DESCRIPTION
- `Error::context`: mark the inner error as the error source. This
  allows a downstream error handler (e.g. anyhow) to format the error
  chain nicely.
- Rename `Error::Shape` to `Error::MatrixShape` to narrow down the scope
  of the variant. Mark the shape error as the error source.
- Split `Error::Io` into `Error::{read, write}`. Mark the wrapped
  `io::Error` as the error source.
- Do not use debug representations of values in errors, we want their
  string representations instead.
- Remove the `Error` suffix from some variants. They are part of an
  error enum, we know that they are errors :^).